### PR TITLE
Fix CI failures from Phase 3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   pull_request:
   push:
-    branches: [ main ]
+    branches: [ master, develop ]
 
 jobs:
   scan_ruby:
@@ -68,12 +68,16 @@ jobs:
   test:
     runs-on: ubuntu-latest
 
-    # services:
-    #  redis:
-    #    image: valkey/valkey:8
-    #    ports:
-    #      - 6379:6379
-    #    options: --health-cmd "redis-cli ping" --health-interval 10s --health-timeout 5s --health-retries 5
+    services:
+      postgres:
+          image: postgres:15
+          ports:
+            - 5432:5432
+          env:
+            POSTGRES_USER: postgres
+            POSTGRES_PASSWORD: postgres
+            POSTGRES_DB: chi_bus_test
+
     steps:
       - name: Install packages
         run: sudo apt-get update && sudo apt-get install --no-install-recommends -y libvips
@@ -89,42 +93,8 @@ jobs:
       - name: Run tests
         env:
           RAILS_ENV: test
-          # RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
-          # REDIS_URL: redis://localhost:6379/0
+          RAILS_DATABASE_HOST: localhost
+          RAILS_DATABASE_PORT: 5432
+          RAILS_DATABASE_USER: postgres
+          RAILS_DATABASE_PASSWORD: postgres
         run: bin/rails db:test:prepare test
-
-  system-test:
-    runs-on: ubuntu-latest
-
-    # services:
-    #  redis:
-    #    image: valkey/valkey:8
-    #    ports:
-    #      - 6379:6379
-    #    options: --health-cmd "redis-cli ping" --health-interval 10s --health-timeout 5s --health-retries 5
-    steps:
-      - name: Install packages
-        run: sudo apt-get update && sudo apt-get install --no-install-recommends -y libvips
-
-      - name: Checkout code
-        uses: actions/checkout@v6
-
-      - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          bundler-cache: true
-
-      - name: Run System Tests
-        env:
-          RAILS_ENV: test
-          # RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
-          # REDIS_URL: redis://localhost:6379/0
-        run: bin/rails db:test:prepare test:system
-
-      - name: Keep screenshots from failed system tests
-        uses: actions/upload-artifact@v4
-        if: failure()
-        with:
-          name: screenshots
-          path: ${{ github.workspace }}/tmp/screenshots
-          if-no-files-found: ignore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,4 +97,5 @@ jobs:
           RAILS_DATABASE_PORT: 5432
           RAILS_DATABASE_USER: postgres
           RAILS_DATABASE_PASSWORD: postgres
+          GOOGLE_API_KEY: dummy
         run: bin/rails db:test:prepare test

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,2 +1,8 @@
-LineLength:
-  Max: 120
+# Omakase Ruby styling for Rails
+inherit_gem: { rubocop-rails-omakase: rubocop.yml }
+
+# Overwrite or add rules to create your own house style
+#
+# # Use `[a, [b, c]]` not `[ a, [ b, c ] ]`
+# Layout/SpaceInsideArrayLiteralBrackets:
+#   Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -92,5 +92,5 @@ gem "ruby-progressbar"
 gem "simplify_rb"
 gem "simplecov", require: false, group: :test
 gem "minitest-reporters", require: false, group: :test
-gem "rails-erd", groups: [:development, :test]
+gem "rails-erd", groups: [ :development, :test ]
 gem "rails-controller-testing"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -136,6 +136,7 @@ GEM
       tzinfo
     execjs (2.10.1)
     ffi (1.17.4-aarch64-linux-gnu)
+    ffi (1.17.4-x86_64-linux-gnu)
     fugit (1.12.1)
       et-orbi (~> 1.4)
       raabro (~> 1.4)
@@ -234,12 +235,15 @@ GEM
     nio4r (2.7.5)
     nokogiri (1.19.3-aarch64-linux-gnu)
       racc (~> 1.4)
+    nokogiri (1.19.3-x86_64-linux-gnu)
+      racc (~> 1.4)
     ostruct (0.6.3)
     parallel (2.1.0)
     parser (3.3.11.1)
       ast (~> 2.4.1)
       racc
     pg (1.6.3-aarch64-linux)
+    pg (1.6.3-x86_64-linux)
     pp (0.6.3)
       prettyprint
     prettyprint (0.2.0)
@@ -410,6 +414,7 @@ GEM
       execjs (>= 0.3.0, < 3)
     thor (1.5.0)
     thruster (0.1.20-aarch64-linux)
+    thruster (0.1.20-x86_64-linux)
     tilt (2.7.0)
     timeout (0.6.1)
     tsort (0.2.0)
@@ -438,6 +443,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   bootsnap

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,3 +1,5 @@
 //= link_tree ../images
 //= link_directory ../javascripts .js
 //= link_directory ../stylesheets .css
+//= link_tree ../../javascript .js
+//= link_tree ../../../vendor/javascript .js

--- a/app/controllers/bus_routes_controller.rb
+++ b/app/controllers/bus_routes_controller.rb
@@ -1,5 +1,5 @@
 class BusRoutesController < ApplicationController
   def show
-    @bus_route = BusRoute.includes(bus_stops: [:bus_route_bus_stops]).order('bus_route_bus_stops.bus_stop_number').find(params[:id])
+    @bus_route = BusRoute.includes(bus_stops: [ :bus_route_bus_stops ]).order("bus_route_bus_stops.bus_stop_number").find(params[:id])
   end
 end

--- a/app/controllers/bus_stops_controller.rb
+++ b/app/controllers/bus_stops_controller.rb
@@ -1,26 +1,26 @@
 class BusStopsController < ApplicationController
   def index
     if params[:q] then
-      @bus_stops = BusStop.preload(:bus_routes).where('lower(keyword) like lower(?)', "%#{params[:q]}%").order('name, latitude DESC').limit(100)
+      @bus_stops = BusStop.preload(:bus_routes).where("lower(keyword) like lower(?)", "%#{params[:q]}%").order("name, latitude DESC").limit(100)
       if @bus_stops.empty?
         client = GooglePlaces::Client.new(ENV["GOOGLE_API_KEY"])
         spots = Rails.cache.fetch(params[:q]) do
           # The maximum allowed radius is 50,000 meters in Google Places API Web Service
           # 千葉県庁@35.6049233,140.1208483
-          client.spots_by_query(params[:q], lat: 35.6049233, lng: 140.1208483, radius: 50_000, language: 'ja')
+          client.spots_by_query(params[:q], lat: 35.6049233, lng: 140.1208483, radius: 50_000, language: "ja")
         end
         @bus_stops = spots.map { |spot| Place.new(spot) }
       end
     elsif params[:position]
-      latitude = params[:position].split(',')[0].to_f
-      longitude = params[:position].split(',')[1].to_f
-      @bus_stops = BusStop.preload(:bus_routes).near([latitude, longitude], 20000).limit(12)
+      latitude = params[:position].split(",")[0].to_f
+      longitude = params[:position].split(",")[1].to_f
+      @bus_stops = BusStop.preload(:bus_routes).near([ latitude, longitude ], 20000).limit(12)
     else
       @bus_stops = []
     end
   end
 
   def show
-    @bus_stop = BusStop.preload(bus_routes: [:bus_stops, :bus_route_tracks]).find(params[:id])
+    @bus_stop = BusStop.preload(bus_routes: [ :bus_stops, :bus_route_tracks ]).find(params[:id])
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -2,17 +2,17 @@ module ApplicationHelper
   def build_markers(bus_stops, position = nil)
     markers = []
     if position then
-      markers += Gmaps4rails.build_markers([position]) do |p, marker|
-        marker.lat p.split(',')[0]
-        marker.lng p.split(',')[1]
-        marker.picture({ url: image_path('bluedot.png'), width: '20', height: '20' })
+      markers += Gmaps4rails.build_markers([ position ]) do |p, marker|
+        marker.lat p.split(",")[0]
+        marker.lng p.split(",")[1]
+        marker.picture({ url: image_path("bluedot.png"), width: "20", height: "20" })
       end
     end
     markers += Gmaps4rails.build_markers(bus_stops) do |bus_stop, marker|
       marker.lat bus_stop.latitude
       marker.lng bus_stop.longitude
       marker.title bus_stop.name
-      marker.infowindow render partial: 'application/infowindow', locals: { bus_stop: bus_stop }
+      marker.infowindow render partial: "application/infowindow", locals: { bus_stop: bus_stop }
       marker.json({ id: bus_stop.id })
     end
     markers
@@ -32,8 +32,8 @@ module ApplicationHelper
   end
 
   def gravatar_for(email, size)
-    gravatar_id = Digest::MD5::hexdigest(email.downcase)
+    gravatar_id = Digest::MD5.hexdigest(email.downcase)
     gravatar_url = "https://secure.gravatar.com/avatar/#{gravatar_id}?s=#{size}"
-    image_tag(gravatar_url, class: 'gravatar')
+    image_tag(gravatar_url, class: "gravatar")
   end
 end

--- a/app/helpers/bus_stops_helper.rb
+++ b/app/helpers/bus_stops_helper.rb
@@ -9,7 +9,7 @@ module BusStopsHelper
 
   def bus_stop_badge(bus_stop)
     if bus_stop.is_a? Place then
-      '周辺'
+      "周辺"
     else
       bus_stop.bus_routes.size
     end

--- a/app/javascript/main.js
+++ b/app/javascript/main.js
@@ -1,0 +1,1 @@
+// Configure your import map in config/importmap.rb. Read more: https://github.com/rails/importmap-rails

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,4 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: 'from@example.com'
-  layout 'mailer'
+  default from: "from@example.com"
+  layout "mailer"
 end

--- a/app/models/bus_stop.rb
+++ b/app/models/bus_stop.rb
@@ -1,14 +1,14 @@
 class BusStop < ApplicationRecord
   has_many :bus_route_bus_stops
-  has_many :bus_routes, -> { order('operation_company, line_name') }, through: :bus_route_bus_stops
+  has_many :bus_routes, -> { order("operation_company, line_name") }, through: :bus_route_bus_stops
   reverse_geocoded_by :latitude, :longitude, address: :formatted_address do |model, results|
     geo = results.first
     if geo
       model.postal_code = geo.postal_code
       # model.prefecture = geo.state # Imported db/seeds.rb
-      city_node = geo.address_components.find { |c| c['types'] == ['locality', 'political'] }
-      model.city = city_node['long_name'] if city_node
-      model.formatted_address = geo.formatted_address.sub('日本, ', '')
+      city_node = geo.address_components.find { |c| c["types"] == [ "locality", "political" ] }
+      model.city = city_node["long_name"] if city_node
+      model.formatted_address = geo.formatted_address.sub("日本, ", "")
     end
   end
 

--- a/app/models/place.rb
+++ b/app/models/place.rb
@@ -11,7 +11,7 @@ class Place
   end
 
   def formatted_address
-    @spot.formatted_address.sub('日本, ', '')
+    @spot.formatted_address.sub("日本, ", "")
   end
 
   def city

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -20,6 +20,7 @@
     <%= analytics_init if GoogleAnalytics.valid_tracker? %>
     <script src="//maps.google.com/maps/api/js?key=AIzaSyDgBqFhJHIOXtF32jGmkFeNzbt6EMYGDKE&libraries=geometry"></script>
     <script src="//cdn.rawgit.com/mahnunchik/markerclustererplus/master/dist/markerclusterer.min.js"></script>
+    <%= javascript_importmap_tags "main" %>
   </head>
   <body>
     <div class="turbolinks-loading"></div>

--- a/bin/importmap
+++ b/bin/importmap
@@ -1,0 +1,4 @@
+#!/usr/bin/env ruby
+
+require_relative "../config/application"
+require "importmap/commands"

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -1,0 +1,3 @@
+# Pin npm packages by running ./bin/importmap
+
+pin "main"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
-  resources :bus_routes, only: [:show]
-  resources :bus_stops, only: [:index, :show]
-  get 'about', to: 'about#index'
-  root 'home#index'
+  resources :bus_routes, only: [ :show ]
+  resources :bus_stops, only: [ :index, :show ]
+  get "about", to: "about#index"
+  root "home#index"
 end

--- a/config/sitemap.rb
+++ b/config/sitemap.rb
@@ -1,15 +1,15 @@
 # Set the host name for URL creation
-SitemapGenerator::Sitemap.default_host = 'https://www.chi-bus.jp'
+SitemapGenerator::Sitemap.default_host = "https://www.chi-bus.jp"
 
 SitemapGenerator::Sitemap.create do
-  add root_path, priority: 0.7, changefreq: 'monthly'
-  add about_path, priority: 0.7, changefreq: 'monthly'
+  add root_path, priority: 0.7, changefreq: "monthly"
+  add about_path, priority: 0.7, changefreq: "monthly"
 
   BusStop.find_each do |bus_stop|
-    add bus_stop_path(bus_stop), lastmod: bus_stop.updated_at, changefreq: 'monthly'
+    add bus_stop_path(bus_stop), lastmod: bus_stop.updated_at, changefreq: "monthly"
   end
 
   BusRoute.find_each do |bus_route|
-    add bus_route_path(bus_route), lastmod: bus_route.updated_at, changefreq: 'monthly'
+    add bus_route_path(bus_route), lastmod: bus_route.updated_at, changefreq: "monthly"
   end
 end

--- a/db/migrate/20160422144635_add_index_to_bus_route_infos.rb
+++ b/db/migrate/20160422144635_add_index_to_bus_route_infos.rb
@@ -1,5 +1,5 @@
 class AddIndexToBusRouteInfos < ActiveRecord::Migration
   def change
-    add_index :bus_route_infos, [:bus_type, :operation_company, :line_name], name: 'index_bus_route_infos_on_bus_type_operation_company_line_name'
+    add_index :bus_route_infos, [ :bus_type, :operation_company, :line_name ], name: 'index_bus_route_infos_on_bus_type_operation_company_line_name'
   end
 end

--- a/db/migrate/20160422145837_add_index_to_bus_route_infos_stops.rb
+++ b/db/migrate/20160422145837_add_index_to_bus_route_infos_stops.rb
@@ -1,6 +1,6 @@
 class AddIndexToBusRouteInfosStops < ActiveRecord::Migration
   def change
-      add_index :bus_route_infos_stops, [:bus_route_info_id, :bus_stop_id], name: 'index_bus_route_infos_stops_on_bus_route_info_id_bus_stop_id'
-      add_index :bus_route_infos_stops, [:bus_stop_id, :bus_route_info_id], name: 'index_bus_route_infos_stops_on_bus_stop_id_bus_route_info_id'
+      add_index :bus_route_infos_stops, [ :bus_route_info_id, :bus_stop_id ], name: 'index_bus_route_infos_stops_on_bus_route_info_id_bus_stop_id'
+      add_index :bus_route_infos_stops, [ :bus_stop_id, :bus_route_info_id ], name: 'index_bus_route_infos_stops_on_bus_stop_id_bus_route_info_id'
   end
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -8,18 +8,18 @@
 
 require 'nokogiri'
 
-def load_bus_route_track xml_path, doc
+def load_bus_route_track(xml_path, doc)
   progress = ProgressBar.create(title: "BusRouteTrack", total: doc.css('Curve').count, format: '%t: %J%% |%B|')
   doc.css('Curve').each do |node|
     gml_id = node['id']
     coordinates = node.at('posList').text.strip.each_line.map { |line| { x: line.split[0].to_f, y: line.split[1].to_f } }
-    simplified_coordinates = SimplifyRb::Simplifier.new.process(coordinates, 0.0001).map { |c| [c[:x], c[:y]] }
+    simplified_coordinates = SimplifyRb::Simplifier.new.process(coordinates, 0.0001).map { |c| [ c[:x], c[:y] ] }
     BusRouteTrack.create(gml_id: "#{xml_path}/#{gml_id}", coordinates: simplified_coordinates)
     progress.increment
   end
 end
 
-def load_bus_routes xml_path
+def load_bus_routes(xml_path)
   doc = Nokogiri::XML(open(xml_path))
   doc.remove_namespaces!
 
@@ -49,7 +49,7 @@ def load_bus_routes xml_path
   end
 end
 
-def load_bus_stops xml_path, prefecture
+def load_bus_stops(xml_path, prefecture)
   doc = Nokogiri::XML(open(xml_path))
   doc.remove_namespaces!
 

--- a/lib/tasks/bus_stop_number.rake
+++ b/lib/tasks/bus_stop_number.rake
@@ -1,13 +1,13 @@
 namespace :bus_stop_number do
-  desc 'Generate bus stop number'
+  desc "Generate bus stop number"
   task generate: :environment do
-    progress = ProgressBar.create(title: "Generate", total: BusRoute.count, format: '%t: %J%% |%B|')
+    progress = ProgressBar.create(title: "Generate", total: BusRoute.count, format: "%t: %J%% |%B|")
     ActiveRecord::Base.transaction do
       BusRouteBusStop.update_all(bus_stop_number: nil)
       BusRoute.find_each do |bus_route|
         index = 0
         bus_route_bus_stops = bus_route.bus_route_bus_stops
-        bus_route.bus_route_tracks.sort_by{ |t| t.coordinates[0][1] }.each do |track|
+        bus_route.bus_route_tracks.sort_by { |t| t.coordinates[0][1] }.each do |track|
           track.coordinates.each do |coordinate|
             latitude = coordinate[0]
             longitude = coordinate[1]
@@ -28,10 +28,10 @@ namespace :bus_stop_number do
     end
   end
 
-  desc 'Dump bus stop number'
+  desc "Dump bus stop number"
   task dump: :environment do
-    progress = ProgressBar.create(title: "Dump", total: BusRouteBusStop.count, format: '%t: %J%% |%B|')
-    File.write('db/bus_stop_number.json', JSON.pretty_generate(
+    progress = ProgressBar.create(title: "Dump", total: BusRouteBusStop.count, format: "%t: %J%% |%B|")
+    File.write("db/bus_stop_number.json", JSON.pretty_generate(
       BusRouteBusStop.find_each.map do |bus_route_bus_stop|
         progress.increment
         {
@@ -42,15 +42,15 @@ namespace :bus_stop_number do
     ))
   end
 
-  desc 'Restore bus stop number'
+  desc "Restore bus stop number"
   task restore: :environment do
-    records = JSON.parse(File.read('db/bus_stop_number.json'))
-    progress = ProgressBar.create(title: "Restore", total: records.count, format: '%t: %J%% |%B|')
+    records = JSON.parse(File.read("db/bus_stop_number.json"))
+    progress = ProgressBar.create(title: "Restore", total: records.count, format: "%t: %J%% |%B|")
     ActiveRecord::Base.transaction do
       records.each do |record|
-        bus_route_bus_stop = BusRouteBusStop.find record['bus_route_bus_stop_id']
+        bus_route_bus_stop = BusRouteBusStop.find record["bus_route_bus_stop_id"]
         bus_route_bus_stop.update(
-          bus_stop_number: record['bus_stop_number']
+          bus_stop_number: record["bus_stop_number"]
         )
         progress.increment
       end

--- a/lib/tasks/geocode.rake
+++ b/lib/tasks/geocode.rake
@@ -1,8 +1,8 @@
 namespace :geocode do
-  desc 'Generate geocording data'
+  desc "Generate geocording data"
   task generate: :environment do
-    query = BusStop.where(formatted_address: nil);
-    progress = ProgressBar.create(title: "Generate", total: query.count, format: '%t: %J%% |%B|')
+    query = BusStop.where(formatted_address: nil)
+    progress = ProgressBar.create(title: "Generate", total: query.count, format: "%t: %J%% |%B|")
     query.find_each.each do |bus_stop|
       bus_stop.reverse_geocode
       bus_stop.save!
@@ -10,10 +10,10 @@ namespace :geocode do
     end
   end
 
-  desc 'Dump geocording data'
+  desc "Dump geocording data"
   task dump: :environment do
-    progress = ProgressBar.create(title: "Dump", total: BusStop.count, format: '%t: %J%% |%B|')
-    File.write('db/geocording_data.json', JSON.pretty_generate(
+    progress = ProgressBar.create(title: "Dump", total: BusStop.count, format: "%t: %J%% |%B|")
+    File.write("db/geocording_data.json", JSON.pretty_generate(
       BusStop.find_each.map do |bus_stop|
         progress.increment
         {
@@ -26,17 +26,17 @@ namespace :geocode do
     ))
   end
 
-  desc 'Restore geocording data'
+  desc "Restore geocording data"
   task restore: :environment do
-    records = JSON.parse(File.read('db/geocording_data.json'))
-    progress = ProgressBar.create(title: "Restore", total: records.count, format: '%t: %J%% |%B|')
+    records = JSON.parse(File.read("db/geocording_data.json"))
+    progress = ProgressBar.create(title: "Restore", total: records.count, format: "%t: %J%% |%B|")
     ActiveRecord::Base.transaction do
       records.each do |record|
-        bus_stop = BusStop.find record['bus_stop_id']
+        bus_stop = BusStop.find record["bus_stop_id"]
         bus_stop.update(
-          postal_code: record['postal_code'],
-          city: record['city'],
-          formatted_address: record['formatted_address']
+          postal_code: record["postal_code"],
+          city: record["city"],
+          formatted_address: record["formatted_address"]
         )
         progress.increment
       end

--- a/lib/tasks/keyword.rake
+++ b/lib/tasks/keyword.rake
@@ -1,25 +1,25 @@
 namespace :keyword do
-  desc 'Generate keywords'
+  desc "Generate keywords"
   task generate: :environment do
-    progress = ProgressBar.create(title: "Generate", total: BusStop.count, format: '%t: %J%% |%B|')
+    progress = ProgressBar.create(title: "Generate", total: BusStop.count, format: "%t: %J%% |%B|")
     ActiveRecord::Base.transaction do
       BusStop.find_each.each do |bus_stop|
         keyword = [
           bus_stop.name,
-          KakasiParser.kakasi('-Ja -Ha -Ka -ka -Ea -p', bus_stop.name).join(' ').delete('^'),
-          KakasiParser.kakasi('-JH -aH -KH -kH -EH -p', bus_stop.name).join(' '),
-          KakasiParser.kakasi('-JK -aK -HK -kK -EK -p', bus_stop.name).join(' ')
-        ].join(' ')
+          KakasiParser.kakasi("-Ja -Ha -Ka -ka -Ea -p", bus_stop.name).join(" ").delete("^"),
+          KakasiParser.kakasi("-JH -aH -KH -kH -EH -p", bus_stop.name).join(" "),
+          KakasiParser.kakasi("-JK -aK -HK -kK -EK -p", bus_stop.name).join(" ")
+        ].join(" ")
         bus_stop.update(keyword: keyword)
         progress.increment
       end
     end
   end
 
-  desc 'Dump keywords'
+  desc "Dump keywords"
   task dump: :environment do
-    progress = ProgressBar.create(title: "Dump", total: BusStop.count, format: '%t: %J%% |%B|')
-    File.write('db/keywords.json', JSON.pretty_generate(
+    progress = ProgressBar.create(title: "Dump", total: BusStop.count, format: "%t: %J%% |%B|")
+    File.write("db/keywords.json", JSON.pretty_generate(
       BusStop.find_each.map do |bus_stop|
         progress.increment
         {
@@ -30,15 +30,15 @@ namespace :keyword do
     ))
   end
 
-  desc 'Restore keywords'
+  desc "Restore keywords"
   task restore: :environment do
-    records = JSON.parse(File.read('db/keywords.json'))
-    progress = ProgressBar.create(title: "Restore", total: records.count, format: '%t: %J%% |%B|')
+    records = JSON.parse(File.read("db/keywords.json"))
+    progress = ProgressBar.create(title: "Restore", total: records.count, format: "%t: %J%% |%B|")
     ActiveRecord::Base.transaction do
       records.each do |record|
-        bus_stop = BusStop.find record['bus_stop_id']
+        bus_stop = BusStop.find record["bus_stop_id"]
         bus_stop.update(
-          keyword: record['keyword']
+          keyword: record["keyword"]
         )
         progress.increment
       end

--- a/test/controllers/about_controller_test.rb
+++ b/test/controllers/about_controller_test.rb
@@ -1,9 +1,8 @@
-require 'test_helper'
+require "test_helper"
 
 class AboutControllerTest < ActionController::TestCase
   test "should get index" do
     get :index
     assert_response :success
   end
-
 end

--- a/test/controllers/bus_routes_controller_test.rb
+++ b/test/controllers/bus_routes_controller_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require "test_helper"
 
 class BusRoutesControllerTest < ActionController::TestCase
   test "should get show" do

--- a/test/controllers/bus_stops_controller_test.rb
+++ b/test/controllers/bus_stops_controller_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require "test_helper"
 
 class BusStopsControllerTest < ActionController::TestCase
   test "should get index with no query" do
@@ -8,7 +8,7 @@ class BusStopsControllerTest < ActionController::TestCase
   end
 
   test "should get index with bus stop query and hits" do
-    get :index, params: { q: 'Stop' }
+    get :index, params: { q: "Stop" }
     assert_response :success
     bus_stops = assigns(:bus_stops)
     assert bus_stops
@@ -17,13 +17,13 @@ class BusStopsControllerTest < ActionController::TestCase
 
   test "should get index with place query and no hits" do
     instance_mock = Minitest::Mock.new
-    instance_mock.expect :spots_by_query, [], [String], lat: Float, lng: Float, radius: Integer, language: String
+    instance_mock.expect :spots_by_query, [], [ String ], lat: Float, lng: Float, radius: Integer, language: String
     class_mock = Minitest::Mock.new
-    class_mock.expect :new, instance_mock, [String]
+    class_mock.expect :new, instance_mock, [ String ]
     GooglePlaces.send(:remove_const, :Client)
     GooglePlaces::Client = class_mock
 
-    get :index, params: { q: 'no hits' }
+    get :index, params: { q: "no hits" }
     assert_response :success
     bus_stops = assigns(:bus_stops)
     assert bus_stops
@@ -32,21 +32,21 @@ class BusStopsControllerTest < ActionController::TestCase
 
   test "should get index with place query and hits" do
     spot = nil
-    def spot.place_id; 'place_id' end
-    def spot.name; 'name' end
+    def spot.place_id; "place_id" end
+    def spot.name; "name" end
     def spot.lat; 1.5 end
     def spot.lng; 2.5 end
-    def spot.formatted_address; 'formatted_address' end
-    def spot.place_id; 'place_id' end
+    def spot.formatted_address; "formatted_address" end
+    def spot.place_id; "place_id" end
 
     instance_mock = Minitest::Mock.new
-    instance_mock.expect :spots_by_query, [spot], [String], lat: Float, lng: Float, radius: Integer, language: String
+    instance_mock.expect :spots_by_query, [ spot ], [ String ], lat: Float, lng: Float, radius: Integer, language: String
     class_mock = Minitest::Mock.new
-    class_mock.expect :new, instance_mock, [String]
+    class_mock.expect :new, instance_mock, [ String ]
     GooglePlaces.send(:remove_const, :Client)
     GooglePlaces::Client = class_mock
 
-    get :index, params: { q: 'hits' }
+    get :index, params: { q: "hits" }
     assert_response :success
     bus_stops = assigns(:bus_stops)
     assert bus_stops
@@ -55,7 +55,7 @@ class BusStopsControllerTest < ActionController::TestCase
   end
 
   test "should get index with position" do
-    get :index, params: { position: '40.7143528,-74.0059731' }
+    get :index, params: { position: "40.7143528,-74.0059731" }
     assert_response :success
     assert assigns(:bus_stops)
   end
@@ -64,13 +64,13 @@ class BusStopsControllerTest < ActionController::TestCase
     Geocoder::Lookup::Test.add_stub(
       "1.5,1.5", [
         {
-          'latitude'     => 40.7143528,
-          'longitude'    => -74.0059731,
-          'address'      => 'New York, NY, USA',
-          'state'        => 'New York',
-          'state_code'   => 'NY',
-          'country'      => 'United States',
-          'country_code' => 'US'
+          "latitude"     => 40.7143528,
+          "longitude"    => -74.0059731,
+          "address"      => "New York, NY, USA",
+          "state"        => "New York",
+          "state_code"   => "NY",
+          "country"      => "United States",
+          "country_code" => "US"
         }
       ]
     )

--- a/test/controllers/home_controller_test.rb
+++ b/test/controllers/home_controller_test.rb
@@ -1,9 +1,8 @@
-require 'test_helper'
+require "test_helper"
 
 class HomeControllerTest < ActionController::TestCase
   test "should get index" do
     get :index
     assert_response :success
   end
-
 end

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require "test_helper"
 
 class ApplicationHelperTest < ActionView::TestCase
   include ApplicationHelper
@@ -10,8 +10,8 @@ class ApplicationHelperTest < ActionView::TestCase
 
   test "should build_markers return bus stops markers" do
     bus_stops = [
-      BusStop.new(id: 1, latitude: 3.5, longitude: 4.5, name: 'name_1'),
-      BusStop.new(id: 2, latitude: 5.5, longitude: 6.5, name: 'name_2')
+      BusStop.new(id: 1, latitude: 3.5, longitude: 4.5, name: "name_1"),
+      BusStop.new(id: 2, latitude: 5.5, longitude: 6.5, name: "name_2")
     ]
     stub(:render, true) do
       results = build_markers(bus_stops)
@@ -20,31 +20,31 @@ class ApplicationHelperTest < ActionView::TestCase
       assert_equal 1, results[0][:id]
       assert_equal 3.5, results[0][:lat]
       assert_equal 4.5, results[0][:lng]
-      assert_equal 'name_1', results[0][:marker_title]
+      assert_equal "name_1", results[0][:marker_title]
       assert results[0][:infowindow]
 
       assert_equal 2, results[1][:id]
       assert_equal 5.5, results[1][:lat]
       assert_equal 6.5, results[1][:lng]
-      assert_equal 'name_2', results[1][:marker_title]
+      assert_equal "name_2", results[1][:marker_title]
       assert results[1][:infowindow]
     end
   end
 
   test "should build_markers return position markers" do
-    results = build_markers([], '1.5,2.5')
+    results = build_markers([], "1.5,2.5")
     assert_equal 1, results.length
 
-    assert_equal '1.5', results[0][:lat]
-    assert_equal '2.5', results[0][:lng]
-    assert_equal '/images/bluedot.png', results[0][:picture][:url]
-    assert_equal '20', results[0][:picture][:width]
-    assert_equal '20', results[0][:picture][:height]
+    assert_equal "1.5", results[0][:lat]
+    assert_equal "2.5", results[0][:lng]
+    assert_equal "/images/bluedot.png", results[0][:picture][:url]
+    assert_equal "20", results[0][:picture][:width]
+    assert_equal "20", results[0][:picture][:height]
   end
 
   test "should build_markers return bus stops and position markers" do
     stub(:render, true) do
-      results = build_markers([BusStop.new(id: 1)], '1.5,2.5')
+      results = build_markers([ BusStop.new(id: 1) ], "1.5,2.5")
       assert_equal 2, results.length
     end
   end
@@ -57,24 +57,24 @@ class ApplicationHelperTest < ActionView::TestCase
   test "shuld build_routes return bus route hash" do
     bus_routes = [
       BusRoute.new(id: 1) do |bus_route|
-        bus_route.bus_route_tracks.build(coordinates: [[1.5, 2.5]])
-        bus_route.bus_route_tracks.build(coordinates: [[3.5, 4.5]])
+        bus_route.bus_route_tracks.build(coordinates: [ [ 1.5, 2.5 ] ])
+        bus_route.bus_route_tracks.build(coordinates: [ [ 3.5, 4.5 ] ])
       end,
       BusRoute.new(id: 2) do |bus_route|
-        bus_route.bus_route_tracks.build(coordinates: [[5.5, 6.5]])
-        bus_route.bus_route_tracks.build(coordinates: [[7.5, 8.5]])
+        bus_route.bus_route_tracks.build(coordinates: [ [ 5.5, 6.5 ] ])
+        bus_route.bus_route_tracks.build(coordinates: [ [ 7.5, 8.5 ] ])
       end
     ]
 
     results = build_routes(bus_routes)
     assert_equal [
-      { id: 1, tracks: [[{ lat: 1.5, lng: 2.5 }], [{ lat: 3.5, lng: 4.5 }]] },
-      { id: 2, tracks: [[{ lat: 5.5, lng: 6.5 }], [{ lat: 7.5, lng: 8.5 }]] }
+      { id: 1, tracks: [ [ { lat: 1.5, lng: 2.5 } ], [ { lat: 3.5, lng: 4.5 } ] ] },
+      { id: 2, tracks: [ [ { lat: 5.5, lng: 6.5 } ], [ { lat: 7.5, lng: 8.5 } ] ] }
     ], results
   end
 
   test "should gravatar_for return html" do
-    render html: gravatar_for('test@exsample.com', 200)
+    render html: gravatar_for("test@exsample.com", 200)
     assert_select 'img[src="https://secure.gravatar.com/avatar/a90bd84d6878b3b19e23d2aa052935af?s=200"]'
     assert_select 'img[class="gravatar"]'
   end

--- a/test/helpers/bus_stops_helper_test.rb
+++ b/test/helpers/bus_stops_helper_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require "test_helper"
 
 class BusStopsHelperTest < ActionView::TestCase
   include BusStopsHelper
@@ -14,7 +14,7 @@ class BusStopsHelperTest < ActionView::TestCase
     spot.expect :lat, 1.0
     spot.expect :lng, 2.0
     place = Place.new(spot)
-    assert_equal bus_stops_path + '?position=1.0,2.0', bus_stop_or_place_path(place)
+    assert_equal bus_stops_path + "?position=1.0,2.0", bus_stop_or_place_path(place)
   end
 
   test "should bus_stop_badge return bus routes count" do
@@ -27,6 +27,6 @@ class BusStopsHelperTest < ActionView::TestCase
   test "should bus_stop_badge return around string" do
     spot = Minitest::Mock.new
     place = Place.new(spot)
-    assert_equal '周辺', bus_stop_badge(place)
+    assert_equal "周辺", bus_stop_badge(place)
   end
 end

--- a/test/models/bus_route_bus_stop_test.rb
+++ b/test/models/bus_route_bus_stop_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require "test_helper"
 
 class BusRouteBusStopTest < ActiveSupport::TestCase
   test "should new" do

--- a/test/models/bus_route_test.rb
+++ b/test/models/bus_route_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require "test_helper"
 
 class BusRouteTest < ActiveSupport::TestCase
   test "should new" do
@@ -22,20 +22,20 @@ class BusRouteTest < ActiveSupport::TestCase
   test "should bus_type_label return" do
     bus_route = BusRoute.new
     assert_nil bus_route.bus_type_label
-    bus_route.bus_type = 1; assert_equal '路線バス（民間）', bus_route.bus_type_label
-    bus_route.bus_type = 2; assert_equal '路線バス（公営）', bus_route.bus_type_label
-    bus_route.bus_type = 3; assert_equal 'コミュニティバス', bus_route.bus_type_label
-    bus_route.bus_type = 4; assert_equal 'デマンドバス', bus_route.bus_type_label
-    bus_route.bus_type = 5; assert_equal 'その他', bus_route.bus_type_label
+    bus_route.bus_type = 1; assert_equal "路線バス（民間）", bus_route.bus_type_label
+    bus_route.bus_type = 2; assert_equal "路線バス（公営）", bus_route.bus_type_label
+    bus_route.bus_type = 3; assert_equal "コミュニティバス", bus_route.bus_type_label
+    bus_route.bus_type = 4; assert_equal "デマンドバス", bus_route.bus_type_label
+    bus_route.bus_type = 5; assert_equal "その他", bus_route.bus_type_label
   end
 
   test "should bus_route_bus_stops order by bus_stop_number" do
     bus_route = BusRoute.create!
-    bus_route.bus_route_bus_stops << BusRouteBusStop.new(bus_stop_number: 2, bus_stop: BusStop.new(name: '2'))
-    bus_route.bus_route_bus_stops << BusRouteBusStop.new(bus_stop_number: 1, bus_stop: BusStop.new(name: '1'))
+    bus_route.bus_route_bus_stops << BusRouteBusStop.new(bus_stop_number: 2, bus_stop: BusStop.new(name: "2"))
+    bus_route.bus_route_bus_stops << BusRouteBusStop.new(bus_stop_number: 1, bus_stop: BusStop.new(name: "1"))
     assert_equal 1, bus_route.bus_route_bus_stops[0].bus_stop_number
     assert_equal 2, bus_route.bus_route_bus_stops[1].bus_stop_number
-    assert_equal '1', bus_route.bus_stops[0].name
-    assert_equal '2', bus_route.bus_stops[1].name
+    assert_equal "1", bus_route.bus_stops[0].name
+    assert_equal "2", bus_route.bus_stops[1].name
   end
 end

--- a/test/models/bus_route_track_test.rb
+++ b/test/models/bus_route_track_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require "test_helper"
 
 class BusRouteTrackTest < ActiveSupport::TestCase
   test "should new" do
@@ -16,11 +16,11 @@ class BusRouteTrackTest < ActiveSupport::TestCase
     bus_route_track = BusRouteTrack.new
 
     bus_route_track.coordinates = []
-    assert_equal '[]', bus_route_track.coordinates.inspect
+    assert_equal "[]", bus_route_track.coordinates.inspect
     assert_not_equal '"[]"', bus_route_track.coordinates.inspect
 
     bus_route_track.gml_id = []
     assert_equal '"[]"', bus_route_track.gml_id.inspect
-    assert_not_equal '[]', bus_route_track.gml_id.inspect
+    assert_not_equal "[]", bus_route_track.gml_id.inspect
   end
 end

--- a/test/models/bus_stop_test.rb
+++ b/test/models/bus_stop_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require "test_helper"
 
 class BusStopTest < ActiveSupport::TestCase
   test "should new" do
@@ -18,54 +18,54 @@ class BusStopTest < ActiveSupport::TestCase
   end
 
   test "should address return address" do
-    bus_stop = BusStop.new(formatted_address: 'New York, NY, USA')
-    assert_equal 'New York, NY, USA', bus_stop.address
+    bus_stop = BusStop.new(formatted_address: "New York, NY, USA")
+    assert_equal "New York, NY, USA", bus_stop.address
   end
 
   test "should formatted_address return ''" do
-    assert_equal '', BusStop.new.formatted_address
+    assert_equal "", BusStop.new.formatted_address
   end
 
   test "should bus_routes order by operation_company, line_name" do
     bus_stop = BusStop.new
-    bus_stop.bus_route_bus_stops << BusRouteBusStop.new(bus_route: BusRoute.new(operation_company: '2', line_name: '2'))
-    bus_stop.bus_route_bus_stops << BusRouteBusStop.new(bus_route: BusRoute.new(operation_company: '2', line_name: '1'))
-    bus_stop.bus_route_bus_stops << BusRouteBusStop.new(bus_route: BusRoute.new(operation_company: '1', line_name: '2'))
-    bus_stop.bus_route_bus_stops << BusRouteBusStop.new(bus_route: BusRoute.new(operation_company: '1', line_name: '1'))
+    bus_stop.bus_route_bus_stops << BusRouteBusStop.new(bus_route: BusRoute.new(operation_company: "2", line_name: "2"))
+    bus_stop.bus_route_bus_stops << BusRouteBusStop.new(bus_route: BusRoute.new(operation_company: "2", line_name: "1"))
+    bus_stop.bus_route_bus_stops << BusRouteBusStop.new(bus_route: BusRoute.new(operation_company: "1", line_name: "2"))
+    bus_stop.bus_route_bus_stops << BusRouteBusStop.new(bus_route: BusRoute.new(operation_company: "1", line_name: "1"))
     bus_stop.save
 
     bus_stop.reload
-    assert_equal '1', bus_stop.bus_routes[0].operation_company
-    assert_equal '1', bus_stop.bus_routes[0].line_name
-    assert_equal '1', bus_stop.bus_routes[1].operation_company
-    assert_equal '2', bus_stop.bus_routes[1].line_name
-    assert_equal '2', bus_stop.bus_routes[2].operation_company
-    assert_equal '1', bus_stop.bus_routes[2].line_name
-    assert_equal '2', bus_stop.bus_routes[3].operation_company
-    assert_equal '2', bus_stop.bus_routes[3].line_name
+    assert_equal "1", bus_stop.bus_routes[0].operation_company
+    assert_equal "1", bus_stop.bus_routes[0].line_name
+    assert_equal "1", bus_stop.bus_routes[1].operation_company
+    assert_equal "2", bus_stop.bus_routes[1].line_name
+    assert_equal "2", bus_stop.bus_routes[2].operation_company
+    assert_equal "1", bus_stop.bus_routes[2].line_name
+    assert_equal "2", bus_stop.bus_routes[3].operation_company
+    assert_equal "2", bus_stop.bus_routes[3].line_name
   end
 
   test "should reverse_geocode set attributes" do
     Geocoder::Lookup::Test.add_stub(
-      [40.7143528, -74.0059731], [
+      [ 40.7143528, -74.0059731 ], [
         {
-          'postal_code' => '000-0000',
-          'formatted_address' => '日本, Test Address'
+          "postal_code" => "000-0000",
+          "formatted_address" => "日本, Test Address"
         }
       ]
     )
 
     class Geocoder::Result::Test
       def address_components
-        [{ 'types' => ['locality', 'political'], 'long_name' => 'City Name' }]
+        [ { "types" => [ "locality", "political" ], "long_name" => "City Name" } ]
       end
     end
 
-    bus_stop = BusStop.new(latitude: 40.7143528, longitude:-74.0059731)
+    bus_stop = BusStop.new(latitude: 40.7143528, longitude: -74.0059731)
     bus_stop.reverse_geocode
 
-    assert_equal '000-0000', bus_stop.postal_code
-    assert_equal 'City Name', bus_stop.city
-    assert_equal 'Test Address', bus_stop.formatted_address
+    assert_equal "000-0000", bus_stop.postal_code
+    assert_equal "City Name", bus_stop.city
+    assert_equal "Test Address", bus_stop.formatted_address
   end
 end

--- a/test/models/place_test.rb
+++ b/test/models/place_test.rb
@@ -1,5 +1,5 @@
-require 'test_helper'
-require 'minitest/mock'
+require "test_helper"
+require "minitest/mock"
 
 class PlaceTest < ActiveSupport::TestCase
   test "should new" do
@@ -8,18 +8,18 @@ class PlaceTest < ActiveSupport::TestCase
 
   test "should have attributes" do
     spot = Minitest::Mock.new
-    spot.expect :place_id, 'place_id'
-    spot.expect :name, 'name'
+    spot.expect :place_id, "place_id"
+    spot.expect :name, "name"
     spot.expect :lat, 1.5
     spot.expect :lng, 2.5
-    spot.expect :formatted_address, 'formatted_address'
+    spot.expect :formatted_address, "formatted_address"
 
     place = Place.new spot
-    assert_equal 'place_id', place.id
-    assert_equal 'name', place.name
+    assert_equal "place_id", place.id
+    assert_equal "name", place.name
     assert_equal 1.5, place.latitude
     assert_equal 2.5, place.longitude
-    assert_equal 'formatted_address', place.formatted_address
+    assert_equal "formatted_address", place.formatted_address
     assert_nil place.city
     assert spot === place.spot
     assert spot.verify

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,13 +1,13 @@
-require 'simplecov'
-SimpleCov.start 'rails'
+require "simplecov"
+SimpleCov.start "rails"
 
 require "minitest/reporters"
 require "minitest/mock"
 Minitest::Reporters.use!
 
-ENV['RAILS_ENV'] ||= 'test'
-require File.expand_path('../../config/environment', __FILE__)
-require 'rails/test_help'
+ENV["RAILS_ENV"] ||= "test"
+require File.expand_path("../../config/environment", __FILE__)
+require "rails/test_help"
 
 Geocoder.configure(lookup: :test)
 


### PR DESCRIPTION
## 概要

PR #15 でマージされた `.github/workflows/ci.yml`（rails new 8.1.3 のテンプレートそのまま）が 5 ジョブすべて失敗していた状況に対応する。

## コミット構成（軽い順）

| コミット | 内容 |
|---|---|
| `Add x86_64-linux to Gemfile.lock platforms` | bundle install が exit 16 で失敗していた根本原因の修正 |
| `Adopt rubocop-rails-omakase style` | `.rubocop.yml` を rubocop-rails-omakase 継承の最小設定に書き換え、`bin/rubocop -A` で 217 違反を自動修正 |
| `Install importmap-rails for scan_js CI job` | `bin/importmap` 未生成だったのを `bin/rails importmap:install` で導入。Sprockets と名前衝突しないよう entrypoint を `main` に |
| `Configure CI for the project's PostgreSQL setup` | branches を `main` → `master, develop` に修正、test job に PostgreSQL service を追加、system-test job を削除 |

## ローカル確認結果

- `bundle install`: OK
- `bin/rubocop`: no offenses detected
- `bin/brakeman`: no warnings found
- `bin/bundler-audit`: no vulnerabilities found
- `bin/importmap audit`: no vulnerable packages found
- `bin/rails test`: 37 tests / 112 assertions / 0 failures / 0 errors / 0 skips

## CI 修正の方針

- system-test は本プロジェクトでまだ system テストを導入していないため削除（将来導入する際に再追加）
- importmap entrypoint は既存の Sprockets `app/assets/javascripts/application.js` と衝突しないよう `main` に変更
- PostgreSQL service の password は `docker-compose.yml` と揃えて `postgres`

## 残課題（別 PR）

- `rails-controller-testing` 削除（テストを `ActionDispatch::IntegrationTest` に書き換え）
- 本番 `cache_store` 設定（Solid Cache or memory_store の明示）
- CLAUDE.md の現状反映