### PR TITLE
Reduce dependabot update frequency to monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,10 +3,10 @@ updates:
 - package-ecosystem: bundler
   directory: "/"
   schedule:
-    interval: weekly
+    interval: monthly
   open-pull-requests-limit: 10
 - package-ecosystem: github-actions
   directory: "/"
   schedule:
-    interval: weekly
+    interval: monthly
   open-pull-requests-limit: 10


### PR DESCRIPTION
## 概要

趣味プロジェクトのため、`.github/dependabot.yml` の `interval` を `weekly` から `monthly` に変更する。bundler と github-actions の両方が対象。

## 背景

`open-pull-requests-limit: 10` が設定されているため同時 PR 数は自動制限されるが、週次だと毎週通知が来てレビュー負担が大きい。月次に下げることで通知頻度を減らし、まとめて確認できる運用に切り替える。

## 影響範囲

- dependabot の自動 PR が週次 → 月次に
- security update も同じ間隔になる点は注意（緊急の脆弱性対応は手動で対応）