### PR TITLE
Migrate controller tests to ActionDispatch::IntegrationTest

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -93,4 +93,3 @@ gem "simplify_rb"
 gem "simplecov", require: false, group: :test
 gem "minitest-reporters", require: false, group: :test
 gem "rails-erd", groups: [ :development, :test ]
-gem "rails-controller-testing"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -136,6 +136,7 @@ GEM
       tzinfo
     execjs (2.10.1)
     ffi (1.17.4-aarch64-linux-gnu)
+    ffi (1.17.4-arm64-darwin)
     ffi (1.17.4-x86_64-linux-gnu)
     fugit (1.12.1)
       et-orbi (~> 1.4)
@@ -235,6 +236,8 @@ GEM
     nio4r (2.7.5)
     nokogiri (1.19.3-aarch64-linux-gnu)
       racc (~> 1.4)
+    nokogiri (1.19.3-arm64-darwin)
+      racc (~> 1.4)
     nokogiri (1.19.3-x86_64-linux-gnu)
       racc (~> 1.4)
     ostruct (0.6.3)
@@ -243,6 +246,7 @@ GEM
       ast (~> 2.4.1)
       racc
     pg (1.6.3-aarch64-linux)
+    pg (1.6.3-arm64-darwin)
     pg (1.6.3-x86_64-linux)
     pp (0.6.3)
       prettyprint
@@ -282,10 +286,6 @@ GEM
       activesupport (= 8.1.3)
       bundler (>= 1.15.0)
       railties (= 8.1.3)
-    rails-controller-testing (1.0.5)
-      actionpack (>= 5.0.1.rc1)
-      actionview (>= 5.0.1.rc1)
-      activesupport (>= 5.0.1.rc1)
     rails-dom-testing (2.3.0)
       activesupport (>= 5.0.0)
       minitest
@@ -414,6 +414,7 @@ GEM
       execjs (>= 0.3.0, < 3)
     thor (1.5.0)
     thruster (0.1.20-aarch64-linux)
+    thruster (0.1.20-arm64-darwin)
     thruster (0.1.20-x86_64-linux)
     tilt (2.7.0)
     timeout (0.6.1)
@@ -443,6 +444,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  arm64-darwin-25
   x86_64-linux
 
 DEPENDENCIES
@@ -471,7 +473,6 @@ DEPENDENCIES
   propshaft
   puma (>= 5.0)
   rails (~> 8.1.3)
-  rails-controller-testing
   rails-erd
   rubocop-rails-omakase
   ruby-progressbar

--- a/test/controllers/about_controller_test.rb
+++ b/test/controllers/about_controller_test.rb
@@ -1,8 +1,8 @@
 require "test_helper"
 
-class AboutControllerTest < ActionController::TestCase
+class AboutControllerTest < ActionDispatch::IntegrationTest
   test "should get index" do
-    get :index
+    get about_path
     assert_response :success
   end
 end

--- a/test/controllers/bus_routes_controller_test.rb
+++ b/test/controllers/bus_routes_controller_test.rb
@@ -1,9 +1,8 @@
 require "test_helper"
 
-class BusRoutesControllerTest < ActionController::TestCase
+class BusRoutesControllerTest < ActionDispatch::IntegrationTest
   test "should get show" do
-    get :show, params: { id: bus_routes(:one) }
+    get bus_route_path(bus_routes(:one))
     assert_response :success
-    assert assigns(:bus_route)
   end
 end

--- a/test/controllers/bus_stops_controller_test.rb
+++ b/test/controllers/bus_stops_controller_test.rb
@@ -1,18 +1,16 @@
 require "test_helper"
 
-class BusStopsControllerTest < ActionController::TestCase
+class BusStopsControllerTest < ActionDispatch::IntegrationTest
   test "should get index with no query" do
-    get :index
+    get bus_stops_path
     assert_response :success
-    assert assigns(:bus_stops)
+    assert_select "p", text: "検索結果はありません。"
   end
 
   test "should get index with bus stop query and hits" do
-    get :index, params: { q: "Stop" }
+    get bus_stops_path, params: { q: "Stop" }
     assert_response :success
-    bus_stops = assigns(:bus_stops)
-    assert bus_stops
-    assert_equal 2, bus_stops.length
+    assert_select "a.list-group-item", count: 2
   end
 
   test "should get index with place query and no hits" do
@@ -23,11 +21,11 @@ class BusStopsControllerTest < ActionController::TestCase
     GooglePlaces.send(:remove_const, :Client)
     GooglePlaces::Client = class_mock
 
-    get :index, params: { q: "no hits" }
+    get bus_stops_path, params: { q: "no hits" }
     assert_response :success
-    bus_stops = assigns(:bus_stops)
-    assert bus_stops
-    assert_equal 0, bus_stops.length
+    assert_select "p", text: "検索結果はありません。"
+    instance_mock.verify
+    class_mock.verify
   end
 
   test "should get index with place query and hits" do
@@ -46,18 +44,17 @@ class BusStopsControllerTest < ActionController::TestCase
     GooglePlaces.send(:remove_const, :Client)
     GooglePlaces::Client = class_mock
 
-    get :index, params: { q: "hits" }
+    get bus_stops_path, params: { q: "hits" }
     assert_response :success
-    bus_stops = assigns(:bus_stops)
-    assert bus_stops
-    assert_equal 1, bus_stops.length
-    assert_instance_of Place, bus_stops[0]
+    assert_select "a.list-group-item", count: 1
+    assert_select "div.badge", text: "周辺"
+    instance_mock.verify
+    class_mock.verify
   end
 
   test "should get index with position" do
-    get :index, params: { position: "40.7143528,-74.0059731" }
+    get bus_stops_path, params: { position: "40.7143528,-74.0059731" }
     assert_response :success
-    assert assigns(:bus_stops)
   end
 
   test "should get show" do
@@ -75,8 +72,7 @@ class BusStopsControllerTest < ActionController::TestCase
       ]
     )
 
-    get :show, params: { id: bus_stops(:one) }
+    get bus_stop_path(bus_stops(:one))
     assert_response :success
-    assert assigns(:bus_stop)
   end
 end

--- a/test/controllers/home_controller_test.rb
+++ b/test/controllers/home_controller_test.rb
@@ -1,8 +1,8 @@
 require "test_helper"
 
-class HomeControllerTest < ActionController::TestCase
+class HomeControllerTest < ActionDispatch::IntegrationTest
   test "should get index" do
-    get :index
+    get root_path
     assert_response :success
   end
 end


### PR DESCRIPTION
## 概要

Rails 5+ で `rails generate` のデフォルトとなった `ActionDispatch::IntegrationTest` に 4 つの controller test を書き換え、`rails-controller-testing` gem を Gemfile から削除する。

## 変更点

### Gemfile
- `gem "rails-controller-testing"` を削除

### test/controllers/*
- クラス継承を `ActionController::TestCase` → `ActionDispatch::IntegrationTest` に変更
- `get :index` / `get :show` を path helper（`bus_stops_path`、`bus_stop_path(x)`）に変更

### テストの意味の維持
`assigns(:foo)` と `assert_template` が IntegrationTest では使えなくなるため、以下で元のテスト意図を保つ:

- **`assert_select` で response の HTML 構造を確認**
  - "Stop" クエリで `a.list-group-item` が 2 件
  - "no hits" で `<p>検索結果はありません。</p>` が表示
  - Place ラップは `div.badge` text: "周辺" で検証
- **Mock の verify メソッド** で Places API 呼び出し回数を確認

## テスト

```
37 tests, 106 assertions, 0 failures, 0 errors, 0 skips
```

書き換え前は 112 assertions、6 減。検索ロジック（"Stop" → 2 件）と Place ラップの検証は `assert_select` で取り戻している。

## レビューのポイント

- IntegrationTest への書き換え（クラス継承と get の引数）
- `assert_select` の selector が view の HTML 構造と一致しているか
- Mock の `expect` シグネチャと `verify` の組み合わせがテストの意図を保てているか