### PR TITLE
Set cache_store to :memory_store explicitly in production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -46,8 +46,8 @@ Rails.application.configure do
   # Don't log any deprecations.
   config.active_support.report_deprecations = false
 
-  # Replace the default in-process memory cache store with a durable alternative.
-  # config.cache_store = :mem_cache_store
+  # Use the in-process memory cache store explicitly (single-dyno setup).
+  config.cache_store = :memory_store
 
   # Replace the default in-process and non-durable queuing backend for Active Job.
   # config.active_job.queue_adapter = :resque


### PR DESCRIPTION
## 概要

production の `cache_store` を Rails のデフォルト動作と同じ `:memory_store` として明示的に設定する。Phase 1 の `app:update` でコメントアウトされた状態のまま放置されていた設定意図を明確にする。

## 動作への影響

なし。コメントアウト状態でも Rails が暗黙に `:memory_store` を選んでいたため、明示しても挙動は変わらない。`production.rb` を読んだ人が「cache_store を意図的に `:memory_store` にしている」と分かるようにすることが目的。

## 趣味プロジェクトの観点

- dyno が 1 個の運用なら `memory_store` でも view fragment cache や Places API レスポンスのキャッシュは効く（プロセス内で再利用される）
- dyno を増やす場合は `solid_cache_store` や `redis_cache_store` への切り替えを検討する