### PR TITLE
Add Procfile with release phase for db:prepare

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,2 @@
+web: bundle exec puma -C config/puma.rb
+release: bin/rails db:prepare


### PR DESCRIPTION
## 概要

Heroku のリリース時に `db:migrate` が走らない問題に対応するため、`Procfile` を追加し公式の release phase で `db:prepare` を実行するようにする。

## Procfile の内容

```
web: bundle exec puma -C config/puma.rb
release: bin/rails db:prepare
```

## 旧運用との関係

以前は `gunpowderlabs/buildpack-ruby-rake-deploy-tasks` サードパーティ buildpack に `DEPLOY_TASKS='db:migrate cache:clear'` を渡してデプロイ時にタスクを実行していた：

```
heroku buildpacks:set https://github.com/heroku/heroku-buildpack-ruby
heroku buildpacks:add https://github.com/gunpowderlabs/buildpack-ruby-rake-deploy-tasks
heroku config:set DEPLOY_TASKS='db:migrate cache:clear'
```

Heroku が release phase を公式サポートしてからは `Procfile` で完結するようになったため、サードパーティ buildpack は不要。

## `db:prepare` の挙動

| 状況 | 実行される処理 |
|---|---|
| **DB 未作成（初回デプロイ）** | `db:create` + `db:schema:load` + `db:seed` |
| **DB 作成済み（2 回目以降）** | `db:migrate` のみ |

初回デプロイでは `db:seed` 経由で `db/seeds.rb` のガードが `data:load` を呼ぶため、`db/data/*.csv` が `COPY FROM STDIN` で投入されて bus データまで揃う。

## `cache:clear` を Procfile に含めない理由

production の `cache_store` を `:memory_store`（プロセスローカル）に切り替えている。dyno は release 後に再起動するためキャッシュは自動でクリアされる。`cache_clear_rails` gem 自体も将来的には削除候補。