### PR TITLE
Pass column names to COPY in data:load

### DIFF
--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -203,7 +203,12 @@ namespace :data do
         path = Rails.root.join("db/data/#{table}.csv")
         raise "Missing #{path}. Run 'rails data:generate' first." unless path.exist?
 
-        raw.copy_data("COPY #{table} FROM STDIN WITH CSV HEADER") do
+        # CSV のヘッダ行を読み、列順を COPY 文に明示する。
+        # COPY ... CSV HEADER はヘッダを読み飛ばすだけで列マッピングをしないため、
+        # CSV と DB の物理カラム順が異なる環境（schema:load 由来など）で壊れる。
+        columns = File.open(path, "r") { |f| f.readline.chomp.split(",") }
+
+        raw.copy_data("COPY #{table} (#{columns.join(', ')}) FROM STDIN WITH CSV HEADER") do
           File.open(path, "r") do |f|
             while (line = f.gets)
               raw.put_copy_data(line)


### PR DESCRIPTION
## 概要

Heroku の release phase で `data:load` が以下のエラーで落ちていた問題の修正：

```
PG::InvalidDatetimeFormat: ERROR:  invalid input syntax for type timestamp: "弘南バス(株)"
CONTEXT:  COPY bus_routes, line 2, column created_at: "弘南バス(株)"
```

## 原因

`COPY ... FROM STDIN WITH CSV HEADER` は **ヘッダ行を読み飛ばすだけで列マッピングはしない** ため、CSV の列順とテーブルの物理カラム順がずれている環境で壊れる。

| 環境 | テーブル作成方法 | 物理カラム順 |
|---|---|---|
| ローカル開発 DB | migration を順次適用 | migration 通り（CSV と一致） |
| Heroku | `db:schema:load` (schema.rb 経由) | **schema.rb のアルファベット順**（CSV と不一致） |

`schema.rb` は dump 時に `t.column` をアルファベット順に並べる。`bus_routes` の場合 `id, bus_type, created_at, holiday_rate, line_name, ...` の順。CSV は `id, bus_type, operation_company, line_name, ...` で `operation_company` の値が `created_at` 列に入ってエラー。

## 修正

`COPY` 文に CSV ヘッダから読み取った列名を明示：

```sql
COPY bus_routes (id, bus_type, operation_company, line_name, weekday_rate, ...) FROM STDIN WITH CSV HEADER
```

CSV の 1 行目（ヘッダ）を読んで `columns.join(', ')` で組み立てる形に修正。

## 再現テスト & 動作確認（ローカル）

1. `DROP TABLE` で既存テーブル削除
2. `bin/rails db:schema:load` で schema.rb から DB 再作成（→ アルファベット順カラムに）
3. 修正前の `data:load` 実行 → **エラー再現**（Heroku と同じ）
4. 本 PR の修正を適用
5. `data:load` 実行 → 全 4 CSV を正常投入
6. ベースライン CSV と diff → 以前と同じ結果（`bus_route_bus_stops` / `bus_route_tracks` 完全一致、`bus_routes` / `bus_stops` はベースライン側の精度ノイズのみ）

## 影響範囲

- ローカル DB（migration 由来）でも引き続き動作する（明示マッピングは何も壊さない）
- Heroku 側でこの PR がリリースされれば、release phase の `db:prepare` 経由で `data:load` が成功するようになる