### PR TITLE
Allow Claude to create branches without explicit instruction

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,8 +19,8 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ### git 操作の確認ルール
 
-- ユーザーは手元で `git diff` を全件レビューしている。**Claude は勝手に `git add` / `commit` / `push` / ブランチ作成 / PR 作成をしない**。
-- ファイル編集自体は通常通り行ってよい。git に反映する操作のみ、明示的な依頼があってから実行する。
+- ユーザーは手元で `git diff` を全件レビューしている。**Claude は勝手に `git add` / `commit` / `push` / PR 作成をしない**。
+- ファイル編集およびブランチ作成は通常通り行ってよい。git に反映する操作（add / commit / push / PR）のみ、明示的な依頼があってから実行する。
 
 ### コミットメッセージ・PR の言語ルール
 


### PR DESCRIPTION
## Summary

- `git 操作の確認ルール` の禁止リストから「ブランチ作成」を除外
- 明示的な依頼が必要な操作を `add` / `commit` / `push` / `PR 作成` の 4 つに整理

## 背景

ブランチ作成は破壊的操作でも共有状態に影響する操作でもなく、ローカルの作業環境に閉じている。明示的な依頼を毎回必須にするほどの慎重さは不要。一方で `add` / `commit` / `push` / `PR 作成` は、共有リポジトリやレビュー対象に影響するため、引き続き明示的な依頼を必須とする。

## Test plan

- [ ] `CLAUDE.md` の該当箇所が正しく書き換わっていることを目視確認