### PR TITLE
Move release tasks from Procfile to buildpack

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,0 @@
-web: bundle exec puma -C config/puma.rb
-release: bin/rails db:prepare

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ docker compose run --rm app bundle exec erd
 
 本番環境は Heroku で、`master` ブランチへの push をトリガーにオートデプロイされます。`develop` で開発し、リリース時に `master` へマージしてください。
 
-`Procfile` の `release` フェーズで `bin/rails db:prepare` が走り、初回デプロイなら `db:create` + `db:schema:load` + `db:seed`（`db/seeds.rb` のガード経由で `data:load` が呼ばれて `db/data/*.csv` を `COPY` 投入）、2 回目以降なら `db:migrate` のみが実行されます。
+DB マイグレーションとキャッシュクリアは buildpack 方式で行います。`gunpowderlabs/buildpack-ruby-rake-deploy-tasks` が `DEPLOY_TASKS` 環境変数に列挙した rake task を build phase で実行するため、出力は build log に流れて Heroku Activity / GitHub の Deployment 画面から確認できます。
 
 初回セットアップが必要な場合：
 
@@ -69,4 +69,13 @@ docker compose run --rm app bundle exec erd
 2. `heroku login`
 3. Heroku Postgres アドオンを追加
 4. config vars に `GOOGLE_API_KEY`、`SECRET_KEY_BASE`、`RAILS_LOG_TO_STDOUT=enabled`、`RAILS_SERVE_STATIC_FILES=enabled` などを設定
-5. GitHub 連携を有効化して `master` ブランチの自動デプロイを ON
+5. buildpack と `DEPLOY_TASKS` を設定する：
+
+   ```
+   heroku buildpacks:set https://github.com/heroku/heroku-buildpack-ruby
+   heroku buildpacks:add https://github.com/gunpowderlabs/buildpack-ruby-rake-deploy-tasks
+   heroku config:set DEPLOY_TASKS='db:migrate cache:clear'
+   ```
+
+6. GitHub 連携を有効化して `master` ブランチの自動デプロイを ON
+7. 初回デプロイ後、データ投入が必要なら `heroku run bin/rails db:seed`（`data:load` 経由で `db/data/*.csv` が `COPY` 投入される）

--- a/README.md
+++ b/README.md
@@ -69,7 +69,13 @@ DB マイグレーションとキャッシュクリアは buildpack 方式で行
 2. `heroku login`
 3. Heroku Postgres アドオンを追加
 4. config vars に `GOOGLE_API_KEY`、`SECRET_KEY_BASE`、`RAILS_LOG_TO_STDOUT=enabled`、`RAILS_SERVE_STATIC_FILES=enabled` などを設定
-5. buildpack と `DEPLOY_TASKS` を設定する：
+5. heroku CLI を対象アプリに関連付ける（以降の `heroku` コマンドで `-a <app名>` を毎回指定しなくて済む。デプロイ自体は GitHub 連携経由なのでこの remote 経由で push する必要はない）：
+
+   ```
+   heroku git:remote -a <app名>
+   ```
+
+6. buildpack と `DEPLOY_TASKS` を設定する：
 
    ```
    heroku buildpacks:set https://github.com/heroku/heroku-buildpack-ruby
@@ -77,5 +83,5 @@ DB マイグレーションとキャッシュクリアは buildpack 方式で行
    heroku config:set DEPLOY_TASKS='db:migrate cache:clear'
    ```
 
-6. GitHub 連携を有効化して `master` ブランチの自動デプロイを ON
-7. 初回デプロイ後、データ投入が必要なら `heroku run bin/rails db:seed`（`data:load` 経由で `db/data/*.csv` が `COPY` 投入される）
+7. GitHub 連携を有効化して `master` ブランチの自動デプロイを ON
+8. 初回デプロイ後、データ投入が必要なら `heroku run bin/rails db:seed`（`data:load` 経由で `db/data/*.csv` が `COPY` 投入される）


### PR DESCRIPTION
## Summary

- `Procfile` を削除し、`gunpowderlabs/buildpack-ruby-rake-deploy-tasks` 経由の `DEPLOY_TASKS` 方式に切り替え
- README.md の Heroku セクションを buildpack 構成に更新、必要な 3 コマンドを記録

## 背景

Procfile の `release` フェーズは失敗時の出力が build log に出ず、app log の release dyno を見ないと気づけない。GitHub オートデプロイ運用では特に不可視で、実際に `Deploy ... release command failed` が起きた際もすぐ気づけなかった（Heroku release 履歴の v197 / v198）。

buildpack 方式では `DEPLOY_TASKS` の rake task が build phase の一部として動くため、出力は build log にそのまま流れる。Heroku Activity / GitHub Deployments から確認でき、可視性が大幅に改善する。失敗すれば build 自体が失敗し、新 release は作られないので防護効果は release phase と同等。

`Procfile` の `web:` 行は heroku/ruby buildpack のデフォルト（puma + `config/puma.rb`）と実質同じで、残す積極的な理由がない。Procfile 自体を削除することで「release phase もここで管理されているのでは」という誤解の余地もなくなる。

## マージ後にやること

このリポジトリの変更だけでは挙動は変わらない。本番反映には Heroku 側で以下のコマンド実行が必要：

```
heroku buildpacks:set https://github.com/heroku/heroku-buildpack-ruby
heroku buildpacks:add https://github.com/gunpowderlabs/buildpack-ruby-rake-deploy-tasks
heroku config:set DEPLOY_TASKS='db:migrate cache:clear'
```

## Test plan

- [ ] README.md の Heroku セクションが buildpack 構成として読み取れることを目視確認
- [ ] `Procfile` が削除されていることを確認
- [ ] マージ後、本番で 3 コマンド実行 → 次回デプロイで build log に DEPLOY_TASKS の出力（`db:migrate` / `cache:clear`）が流れることを確認
