### PR TITLE
Document db:prepare flow in buildpack setup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,8 +14,10 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ### 本番デプロイ
 
 - 本番環境は **Heroku**、`master` ブランチへのマージで **オートデプロイ**される。
-- リリース時の DB 操作は `Procfile` の `release` フェーズで `bin/rails db:prepare` が走る（migration、初回 seed まで自動化）。
+- DB セットアップとキャッシュクリアは buildpack 方式（`gunpowderlabs/buildpack-ruby-rake-deploy-tasks`）で実行する。`DEPLOY_TASKS='db:prepare cache:clear'` を build phase の最後に走らせる構成。release phase ではなく build phase に寄せたのは、release phase の失敗が build log に出ず GitHub オートデプロイ運用では見落としやすかったため（`Procfile` は使わない）。
+- 罠: `db:prepare` は **fresh DB（schema_migrations が空）のときだけ** schema:load + seed を回し、既存 DB では migrate しか走らない。データを完全に投入し直したいときはテーブル定義ごと吹き飛ばす必要があるので `heroku pg:reset DATABASE` を使う。
 - したがって `develop` → `master` の PR マージは「リリース操作そのもの」。マイグレーションの有無、`ENV` 追加、外部 API 呼び出しの増加などの影響範囲を確認したうえで、ユーザーが手動マージする。
+- セットアップ手順とコマンドは `README.md` の「Heroku でのデプロイ」節を参照。
 
 ### git 操作の確認ルール
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ docker compose run --rm app bundle exec erd
 
 本番環境は Heroku で、`master` ブランチへの push をトリガーにオートデプロイされます。`develop` で開発し、リリース時に `master` へマージしてください。
 
-DB マイグレーションとキャッシュクリアは buildpack 方式で行います。`gunpowderlabs/buildpack-ruby-rake-deploy-tasks` が `DEPLOY_TASKS` 環境変数に列挙した rake task を build phase で実行するため、出力は build log に流れて Heroku Activity / GitHub の Deployment 画面から確認できます。
+DB セットアップとキャッシュクリアは buildpack 方式で行います。`gunpowderlabs/buildpack-ruby-rake-deploy-tasks` が `DEPLOY_TASKS` 環境変数に列挙した rake task を build phase で実行するため、出力は build log に流れて Heroku Activity / GitHub の Deployment 画面から確認できます。`db:prepare` は fresh DB なら `schema:load` + `seed`（`db/seeds.rb` のガード経由で `data:load` が呼ばれて `db/data/*.csv` を `COPY` 投入）まで自動で走り、既存 DB では `migrate` のみ実行されます。
 
 初回セットアップが必要な場合：
 
@@ -80,8 +80,7 @@ DB マイグレーションとキャッシュクリアは buildpack 方式で行
    ```
    heroku buildpacks:set https://github.com/heroku/heroku-buildpack-ruby
    heroku buildpacks:add https://github.com/gunpowderlabs/buildpack-ruby-rake-deploy-tasks
-   heroku config:set DEPLOY_TASKS='db:migrate cache:clear'
+   heroku config:set DEPLOY_TASKS='db:prepare cache:clear'
    ```
 
 7. GitHub 連携を有効化して `master` ブランチの自動デプロイを ON
-8. 初回デプロイ後、データ投入が必要なら `heroku run bin/rails db:seed`（`data:load` 経由で `db/data/*.csv` が `COPY` 投入される）


### PR DESCRIPTION
## Summary

- `DEPLOY_TASKS` を `db:prepare cache:clear` 前提に統一（README）
- CLAUDE.md の本番デプロイ節を buildpack 方式に書き換え、`db:prepare` の seed 条件を「罠」として明記
- README から手動 `db:seed` 手順を削除（buildpack で自動化されたため不要）

## 背景

Procfile から buildpack 方式に切り替えた直後は `DEPLOY_TASKS='db:migrate cache:clear'` で運用していたが、初回デプロイ時に seed が走らず本番のテーブルが全て空（`BusStop.count == 0`）になっていた。`db:migrate` には seed 動作が含まれないため、`db/data/*.csv` の投入が永久に発火しない設計上の穴があった。

`db:prepare` に切り替えると、`schema_migrations` が空のときだけ `schema:load` + `seed` まで自動で回り、既存 DB では `migrate` のみ実行される。趣味プロジェクト運用での「DB リセット時にだけ seed したい」要件と一致するため最終形に採用した。

## 検証

- `DEPLOY_TASKS='db:migrate db:version cache:clear'` で deploy → build log に `Current version: 20160522061237` が出ることを確認、buildpack が DEPLOY_TASKS を確実に実行していることを検証
- `DEPLOY_TASKS='db:prepare cache:clear'` に変更後、`heroku pg:reset DATABASE` → 再デプロイ → `BusStop: 53025`, `BusRoute: 7013`, `BusRouteBusStop: 143923`, `BusRouteTrack: 26862` の投入を確認

## 罠の記録

CLAUDE.md に明記したとおり、`db:prepare` は schema_migrations が空のときしか seed しない。データを再投入したいときは migration 履歴ごと飛ばす必要があるので `heroku pg:reset DATABASE` を使う（`heroku run rails db:reset` ではテーブルは消えるが schema_migrations が残る場合があるので注意）。

## Test plan

- [ ] CLAUDE.md の本番デプロイ節が buildpack 方式の説明として読み取れることを目視確認
- [ ] README.md の「Heroku でのデプロイ」節で `DEPLOY_TASKS='db:prepare cache:clear'` になっていること、手動 `db:seed` 手順が削除されていることを確認
