### PR TITLE
Fix home page centering broken by flex parent

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -68,6 +68,7 @@ h1, .h1, h2, .h2, h3, .h3 {
 .home-child {
   margin-top: auto;
   margin-bottom: auto;
+  width: 100%;
 }
 
 .sub-title {


### PR DESCRIPTION
## 概要

トップページのロゴ・リード文・検索窓が左寄りに表示されていた問題を修正します。

## 原因

`.home-parent` に `display: flex` を当てている影響で、直接の子である `.home-child`（Bootstrap の `.row`）が **flex item としてコンテンツ幅まで縮んでいた** のが根本原因です。

- Bootstrap 3 の `.row` は `width` 指定を持たず、ブロック要素として親の幅いっぱいに広がる前提
- flex 環境下では `width: auto` が効いてコンテンツ幅相当に縮む
- 結果として、内側の `col-xs-12 col-sm-offset-4 col-sm-4`（検索窓）のオフセット基準が壊れ、`text-center`（ロゴ・リード文）も「縮んだ親の中での中央」になり、画面に対しては左寄りに表示される

縦方向は `.home-child` の `margin-top/bottom: auto` が flex item に対する余剰スペース分配として機能していたため、縦中央寄せだけは効いている、という非対称な症状でした。

## 修正内容

`.home-child` に `width: 100%` を 1 行追加するだけの最小差分。既存の `margin: auto` による縦中央寄せの仕組みはそのまま温存しています。

## テスト計画

- [x] トップページ（`/`）を PC 幅で開き、ロゴ・リード文・検索窓が画面中央に揃って表示されることを確認
- [x] スマホ幅（< 768px）でも従来どおり `col-xs-12` の全幅レイアウトが崩れないことを確認
- [x] 検索窓にフォーカスが当たる挙動が壊れていないことを確認