### PR TITLE
Strengthen test coverage with system tests, error paths, and threshold

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,3 +99,53 @@ jobs:
           RAILS_DATABASE_PASSWORD: postgres
           GOOGLE_API_KEY: dummy
         run: bin/rails db:test:prepare test
+
+  system-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    services:
+      postgres:
+          image: postgres:15
+          ports:
+            - 5432:5432
+          env:
+            POSTGRES_USER: postgres
+            POSTGRES_PASSWORD: postgres
+            POSTGRES_DB: chi_bus_test
+
+      selenium:
+        image: seleniarm/standalone-chromium:latest
+        ports:
+          - "4444:4444"
+
+    steps:
+      - name: Install packages
+        run: sudo apt-get update && sudo apt-get install --no-install-recommends -y libvips
+
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+
+      - name: Run system tests
+        env:
+          RAILS_ENV: test
+          RAILS_DATABASE_HOST: localhost
+          RAILS_DATABASE_PORT: 5432
+          RAILS_DATABASE_USER: postgres
+          RAILS_DATABASE_PASSWORD: postgres
+          GOOGLE_API_KEY: dummy
+          SELENIUM_REMOTE_URL: http://localhost:4444/wd/hub
+        run: bin/rails db:test:prepare test:system
+
+      - name: Keep screenshots from failed system tests
+        uses: actions/upload-artifact@v7
+        if: failure()
+        with:
+          name: screenshots
+          path: ${{ github.workspace }}/tmp/screenshots
+          if-no-files-found: ignore

--- a/Gemfile
+++ b/Gemfile
@@ -91,4 +91,4 @@ gem "cache_clear_rails"
 gem "ruby-progressbar"
 gem "simplify_rb"
 gem "simplecov", require: false, group: :test
-gem "rails-erd", groups: [ :development, :test ]
+gem "rails-erd", group: :development

--- a/Gemfile
+++ b/Gemfile
@@ -91,5 +91,4 @@ gem "cache_clear_rails"
 gem "ruby-progressbar"
 gem "simplify_rb"
 gem "simplecov", require: false, group: :test
-gem "minitest-reporters", require: false, group: :test
 gem "rails-erd", groups: [ :development, :test ]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,7 +77,6 @@ GEM
       uri (>= 0.13.1)
     addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
-    ansi (1.6.0)
     ast (2.4.3)
     autoprefixer-rails (10.4.21.0)
       execjs (~> 2)
@@ -209,11 +208,6 @@ GEM
     minitest-rails (8.1.0)
       minitest (~> 5.20)
       railties (>= 8.1.0, < 8.2.0)
-    minitest-reporters (1.8.0)
-      ansi
-      builder
-      minitest (>= 5.0, < 7)
-      ruby-progressbar
     msgpack (1.8.0)
     multi_xml (0.9.0)
       bigdecimal (>= 3.1, < 5)
@@ -467,7 +461,6 @@ DEPENDENCIES
   jquery-rails
   kamal
   minitest-rails
-  minitest-reporters
   newrelic_rpm
   pg (~> 1.2)
   propshaft

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -1,0 +1,19 @@
+require "test_helper"
+
+class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
+  url = ENV.fetch("SELENIUM_REMOTE_URL", nil)
+  options = if url
+    { browser: :remote, url: url }
+  else
+    { browser: :chrome }
+  end
+  driven_by :selenium, using: :headless_chrome, options: options
+
+  def setup
+    # docker-compose の selenium コンテナから app コンテナの Puma に接続させる構成のため、
+    # Puma を 0.0.0.0 で待ち受け、ブラウザには現コンテナのアドレスを渡す。
+    Capybara.server_host = "0.0.0.0"
+    Capybara.app_host = "http://#{IPSocket.getaddress(Socket.gethostname)}" if ENV["SELENIUM_REMOTE_URL"].present?
+    super
+  end
+end

--- a/test/controllers/bus_routes_controller_test.rb
+++ b/test/controllers/bus_routes_controller_test.rb
@@ -5,4 +5,9 @@ class BusRoutesControllerTest < ActionDispatch::IntegrationTest
     get bus_route_path(bus_routes(:one))
     assert_response :success
   end
+
+  test "should return 404 for unknown bus_route id" do
+    get bus_route_path(id: 999_999_999)
+    assert_response :not_found
+  end
 end

--- a/test/controllers/bus_stops_controller_test.rb
+++ b/test/controllers/bus_stops_controller_test.rb
@@ -43,6 +43,19 @@ class BusStopsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  test "should get index with malformed position falling back to 0,0" do
+    # `params[:position].split(",")[0].to_f` の挙動上、不正値は (0.0, 0.0) として扱われる。
+    # 例外で 500 にせず正常レスポンスを返すことを明文化する。
+    get bus_stops_path, params: { position: "abc" }
+    assert_response :success
+  end
+
+  test "should prefer q over position when both given" do
+    get bus_stops_path, params: { q: "Stop", position: "1,1" }
+    assert_response :success
+    assert_select "a.list-group-item", count: 2
+  end
+
   test "should get show" do
     Geocoder::Lookup::Test.add_stub(
       "1.5,1.5", [
@@ -60,5 +73,10 @@ class BusStopsControllerTest < ActionDispatch::IntegrationTest
 
     get bus_stop_path(bus_stops(:one))
     assert_response :success
+  end
+
+  test "should return 404 for unknown bus_stop id" do
+    get bus_stop_path(id: 999_999_999)
+    assert_response :not_found
   end
 end

--- a/test/controllers/bus_stops_controller_test.rb
+++ b/test/controllers/bus_stops_controller_test.rb
@@ -14,42 +14,28 @@ class BusStopsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should get index with place query and no hits" do
-    instance_mock = Minitest::Mock.new
-    instance_mock.expect :spots_by_query, [], [ String ], lat: Float, lng: Float, radius: Integer, language: String
-    class_mock = Minitest::Mock.new
-    class_mock.expect :new, instance_mock, [ String ]
-    GooglePlaces.send(:remove_const, :Client)
-    GooglePlaces::Client = class_mock
-
-    get bus_stops_path, params: { q: "no hits" }
-    assert_response :success
-    assert_select "p", text: "検索結果はありません。"
-    instance_mock.verify
-    class_mock.verify
+    with_google_places_stub(spots: []) do
+      get bus_stops_path, params: { q: "no hits" }
+      assert_response :success
+      assert_select "p", text: "検索結果はありません。"
+    end
   end
 
   test "should get index with place query and hits" do
-    spot = nil
-    def spot.place_id; "place_id" end
-    def spot.name; "name" end
-    def spot.lat; 1.5 end
-    def spot.lng; 2.5 end
-    def spot.formatted_address; "formatted_address" end
-    def spot.place_id; "place_id" end
+    spot = GooglePlacesSpot.new(
+      place_id: "place_id",
+      name: "name",
+      lat: 1.5,
+      lng: 2.5,
+      formatted_address: "formatted_address"
+    )
 
-    instance_mock = Minitest::Mock.new
-    instance_mock.expect :spots_by_query, [ spot ], [ String ], lat: Float, lng: Float, radius: Integer, language: String
-    class_mock = Minitest::Mock.new
-    class_mock.expect :new, instance_mock, [ String ]
-    GooglePlaces.send(:remove_const, :Client)
-    GooglePlaces::Client = class_mock
-
-    get bus_stops_path, params: { q: "hits" }
-    assert_response :success
-    assert_select "a.list-group-item", count: 1
-    assert_select "div.badge", text: "周辺"
-    instance_mock.verify
-    class_mock.verify
+    with_google_places_stub(spots: [ spot ]) do
+      get bus_stops_path, params: { q: "hits" }
+      assert_response :success
+      assert_select "a.list-group-item", count: 1
+      assert_select "div.badge", text: "周辺"
+    end
   end
 
   test "should get index with position" do

--- a/test/models/bus_stop_test.rb
+++ b/test/models/bus_stop_test.rb
@@ -45,6 +45,31 @@ class BusStopTest < ActiveSupport::TestCase
     assert_equal "2", bus_stop.bus_routes[3].line_name
   end
 
+  test "should keyword search match by kanji, hiragana, katakana, and romaji" do
+    bus_stop = BusStop.create!(
+      name: "千葉駅",
+      latitude: 35.6049233,
+      longitude: 140.1208483,
+      keyword: "千葉駅 chibaeki ちばえき チバエキ"
+    )
+
+    # コントローラ側で使う SQL と同じ形（lower + like）で各表記が引けることを確認する。
+    [ "千葉", "chiba", "ちば", "チバ" ].each do |query|
+      results = BusStop.where("lower(keyword) like lower(?)", "%#{query}%")
+      assert_includes results, bus_stop, "expected query #{query.inspect} to match"
+    end
+  end
+
+  test "should near return bus stops ordered by distance" do
+    chibaeki = BusStop.create!(name: "千葉駅",     latitude: 35.6049233, longitude: 140.1208483)
+    kaihin   = BusStop.create!(name: "海浜幕張駅", latitude: 35.6489000, longitude: 140.0337000)
+
+    results = BusStop.near([ 35.6049233, 140.1208483 ], 50).to_a
+
+    assert_equal chibaeki, results.first
+    assert_includes results, kaihin
+  end
+
   test "should reverse_geocode set attributes" do
     Geocoder::Lookup::Test.add_stub(
       [ 40.7143528, -74.0059731 ], [

--- a/test/system/bus_stops_search_test.rb
+++ b/test/system/bus_stops_search_test.rb
@@ -1,0 +1,36 @@
+require "application_system_test_case"
+
+class BusStopsSearchTest < ApplicationSystemTestCase
+  test "should show matching bus stops when searching by keyword" do
+    visit root_path
+
+    # `#q` はメニューにも存在するためトップページのフォームに限定する。
+    within ".home-parent form" do
+      fill_in "q", with: "Stop"
+      find("button[type=submit]").click
+    end
+
+    assert_selector "a.list-group-item", count: 2
+  end
+
+  test "should follow link from list to bus stop detail" do
+    Geocoder::Lookup::Test.add_stub(
+      "1.5,1.5", [
+        {
+          "latitude"     => 40.7143528,
+          "longitude"    => -74.0059731,
+          "address"      => "New York, NY, USA",
+          "state"        => "New York",
+          "state_code"   => "NY",
+          "country"      => "United States",
+          "country_code" => "US"
+        }
+      ]
+    )
+
+    visit bus_stops_path(q: "Stop")
+    first("a.list-group-item").click
+
+    assert_selector "h3", text: /BusStop/
+  end
+end

--- a/test/system/home_test.rb
+++ b/test/system/home_test.rb
@@ -1,0 +1,11 @@
+require "application_system_test_case"
+
+class HomeTest < ApplicationSystemTestCase
+  test "should show logo, lead text, and search form" do
+    visit root_path
+
+    assert_selector "h1", text: "chi-bus.jp"
+    assert_selector "p.lead"
+    assert_selector ".home-parent form input#q"
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,5 +1,9 @@
 require "simplecov"
-SimpleCov.start "rails"
+SimpleCov.start "rails" do
+  # 既存値（執筆時点で 94% 超）から大きく下回らない範囲で、新規コードに自然とテストを付ける
+  # 圧力をかける目的の下限値。下げる場合は理由を残すこと。
+  minimum_coverage line: 80
+end
 
 require "minitest/reporters"
 require "minitest/mock"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,9 +1,7 @@
 require "simplecov"
 SimpleCov.start "rails"
 
-require "minitest/reporters"
 require "minitest/mock"
-Minitest::Reporters.use!
 
 ENV["RAILS_ENV"] ||= "test"
 require File.expand_path("../../config/environment", __FILE__)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -11,9 +11,33 @@ require "rails/test_help"
 
 Geocoder.configure(lookup: :test)
 
+# GooglePlaces API レスポンスのスタブで使う最小限の Spot 値オブジェクト。
+# nil への singleton メソッド定義のような副作用のあるパターンを避けるために用意。
+GooglePlacesSpot = Struct.new(:place_id, :name, :lat, :lng, :formatted_address, keyword_init: true)
+
 class ActiveSupport::TestCase
   # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.
   fixtures :all
 
-  # Add more helper methods to be used by all tests here...
+  # `GooglePlaces::Client` を一時的にモックに差し替えるブロックヘルパー。
+  # `remove_const` を直接書くと差し替えが残って後続テストを汚染するため、
+  # ensure で必ず元の定数を復元する。
+  def with_google_places_stub(spots:)
+    instance_mock = Minitest::Mock.new
+    instance_mock.expect :spots_by_query, spots, [ String ], lat: Float, lng: Float, radius: Integer, language: String
+    class_mock = Minitest::Mock.new
+    class_mock.expect :new, instance_mock, [ String ]
+
+    original = GooglePlaces::Client
+    GooglePlaces.send(:remove_const, :Client)
+    GooglePlaces.const_set(:Client, class_mock)
+    begin
+      yield
+      instance_mock.verify
+      class_mock.verify
+    ensure
+      GooglePlaces.send(:remove_const, :Client)
+      GooglePlaces.const_set(:Client, original)
+    end
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,9 +1,5 @@
 require "simplecov"
-SimpleCov.start "rails" do
-  # 既存値（執筆時点で 94% 超）から大きく下回らない範囲で、新規コードに自然とテストを付ける
-  # 圧力をかける目的の下限値。下げる場合は理由を残すこと。
-  minimum_coverage line: 80
-end
+SimpleCov.start "rails"
 
 require "minitest/reporters"
 require "minitest/mock"


### PR DESCRIPTION
## 概要

テスト強化を 5 つの観点で順番に積み上げた PR です。各コミットを観点ごとに分けてあります。

## 含まれる変更（コミット順）

1. **system test の土台導入** (`406c4bf`)
   - `ApplicationSystemTestCase` と `test/system/{home,bus_stops_search}_test.rb` を新設
   - docker-compose の selenium コンテナと `SELENIUM_REMOTE_URL` 経由で連携
   - 先日修正したセンタリング崩れのようなビュー層リグレッションを機械的に検知できるように
2. **GooglePlaces stub をブロックヘルパー化** (`2ecefdf`)
   - `remove_const` で差し替えたあと復元していなかった既存パターンを `with_google_places_stub` に集約
   - 副作用の大きい `def nil.method` パターンを `GooglePlacesSpot` Struct で置き換え
3. **controller の異常系テスト追加** (`96dd39e`)
   - 存在しない id（404）、不正な position（暗黙の (0,0) フォールバック）、`q`+`position` 同時指定時の優先順位を明文化
4. **model の実挙動テスト追加** (`089ecc7`)
   - `keyword` カラムへの漢字 / かな / カナ / ローマ字検索が同一レコードをヒットさせること
   - `BusStop.near` が距離順に並ぶこと
5. **CI に system-test ジョブを追加** (`44b99e1`)
   - 既存 test ジョブとは分離した `system-test` ジョブ。`postgres` + `seleniarm/standalone-chromium` を services として起動し `SELENIUM_REMOTE_URL` を渡す
   - 失敗時は `tmp/screenshots/` を artifact として upload

> 補足: 当初は SimpleCov の `minimum_coverage line: 80` も入れていた（`ec80ce5`）が、system test 単独実行で閾値を下回るため CI 構成が複雑化することがわかり、`9b7322d` で取り除いた。レポート生成自体は残している。

## テスト結果（ローカル）

`bin/rails test:all` で 46 tests / 127 assertions / 0 failures。

## Test plan

- [x] `docker-compose run --rm app bin/rails test:all` がローカルでグリーンになる
- [x] `docker-compose run --rm app bin/rails test:system` で system test 単独実行も成功する
- [x] CI の `test` ジョブ（unit）がグリーン
- [x] CI の `system-test` ジョブ（system）がグリーン
- [x] 万一 CI の system-test が落ちた場合、`screenshots` artifact を確認して原因切り分け