### PR TITLE
Strengthen model and controller tests with branch coverage

### DIFF
--- a/test/controllers/about_controller_test.rb
+++ b/test/controllers/about_controller_test.rb
@@ -5,4 +5,10 @@ class AboutControllerTest < ActionDispatch::IntegrationTest
     get about_path
     assert_response :success
   end
+
+  test "should render service description sections" do
+    get about_path
+    assert_select "h2", text: "chi-bus.jpについて"
+    assert_select ".panel-heading", text: "このサービスは何ですか？"
+  end
 end

--- a/test/controllers/bus_routes_controller_test.rb
+++ b/test/controllers/bus_routes_controller_test.rb
@@ -10,4 +10,20 @@ class BusRoutesControllerTest < ActionDispatch::IntegrationTest
     get bus_route_path(id: 999_999_999)
     assert_response :not_found
   end
+
+  test "should list bus_stops in bus_stop_number order" do
+    route = bus_routes(:one)
+    later   = BusStop.create!(name: "Later Stop",   latitude: 1.0, longitude: 1.0)
+    earlier = BusStop.create!(name: "Earlier Stop", latitude: 2.0, longitude: 2.0)
+    # 作成順は逆だが、bus_stop_number 順で並ぶことを期待する。
+    BusRouteBusStop.create!(bus_route: route, bus_stop: later,   bus_stop_number: 2)
+    BusRouteBusStop.create!(bus_route: route, bus_stop: earlier, bus_stop_number: 1)
+
+    get bus_route_path(route)
+    assert_response :success
+
+    body = @response.body
+    assert body.index("Earlier Stop") < body.index("Later Stop"),
+      "Earlier Stop should appear before Later Stop in bus_stop_number order"
+  end
 end

--- a/test/controllers/bus_stops_controller_test.rb
+++ b/test/controllers/bus_stops_controller_test.rb
@@ -38,6 +38,27 @@ class BusStopsControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test "should cache GooglePlaces results by query string" do
+    # test 環境のキャッシュは :null_store で何も保持しないため、本テストの間だけ
+    # memory_store に差し替えてキャッシュ動作を検証する。
+    original_cache = Rails.cache
+    Rails.cache = ActiveSupport::Cache::MemoryStore.new
+    begin
+      # `with_google_places_stub` は `spots_by_query` を 1 回しか期待しない Mock を作るため、
+      # 同じ q で 2 回 GET しても 2 回目はキャッシュから返って API が叩かれず、
+      # 終了時の mock.verify が成功する。逆にキャッシュが効かなければ verify が失敗する。
+      with_google_places_stub(spots: []) do
+        get bus_stops_path, params: { q: "cached query" }
+        assert_response :success
+
+        get bus_stops_path, params: { q: "cached query" }
+        assert_response :success
+      end
+    ensure
+      Rails.cache = original_cache
+    end
+  end
+
   test "should get index with position" do
     get bus_stops_path, params: { position: "40.7143528,-74.0059731" }
     assert_response :success

--- a/test/controllers/bus_stops_controller_test.rb
+++ b/test/controllers/bus_stops_controller_test.rb
@@ -7,6 +7,15 @@ class BusStopsControllerTest < ActionDispatch::IntegrationTest
     assert_select "p", text: "検索結果はありません。"
   end
 
+  test "should treat empty q as match-all keyword search" do
+    # `if params[:q]` は空文字でも truthy なので keyword 分岐に入り、
+    # `lower(keyword) like '%%'` で全件にヒットする。fixture が 2 件のため 2 件返る。
+    # Google Places フォールバックには行かない（`@bus_stops.empty?` が偽）。
+    get bus_stops_path, params: { q: "" }
+    assert_response :success
+    assert_select "a.list-group-item", count: 2
+  end
+
   test "should get index with bus stop query and hits" do
     get bus_stops_path, params: { q: "Stop" }
     assert_response :success

--- a/test/controllers/home_controller_test.rb
+++ b/test/controllers/home_controller_test.rb
@@ -5,4 +5,10 @@ class HomeControllerTest < ActionDispatch::IntegrationTest
     get root_path
     assert_response :success
   end
+
+  test "should render logo and search form" do
+    get root_path
+    assert_select "h1", text: /chi-bus\.jp/
+    assert_select ".home-parent form input#q"
+  end
 end

--- a/test/models/bus_route_bus_stop_test.rb
+++ b/test/models/bus_route_bus_stop_test.rb
@@ -11,4 +11,16 @@ class BusRouteBusStopTest < ActiveSupport::TestCase
     assert_respond_to bus_route_bus_stop, :bus_route
     assert_respond_to bus_route_bus_stop, :bus_stop
   end
+
+  test "should require bus_route" do
+    brbs = BusRouteBusStop.new(bus_stop: bus_stops(:one), bus_stop_number: 1)
+    refute brbs.valid?
+    assert_includes brbs.errors[:bus_route], "must exist"
+  end
+
+  test "should require bus_stop" do
+    brbs = BusRouteBusStop.new(bus_route: bus_routes(:one), bus_stop_number: 1)
+    refute brbs.valid?
+    assert_includes brbs.errors[:bus_stop], "must exist"
+  end
 end

--- a/test/models/bus_route_test.rb
+++ b/test/models/bus_route_test.rb
@@ -29,6 +29,17 @@ class BusRouteTest < ActiveSupport::TestCase
     bus_route.bus_type = 5; assert_equal "その他", bus_route.bus_type_label
   end
 
+  test "should bus_type_label work with symbol and string setters" do
+    # 実装は `bus_type.to_s.to_sym` で吸収しているため、enum へ整数・シンボル・文字列の
+    # どれを渡しても同じラベルが返ることを確認する。
+    bus_route = BusRoute.new
+    bus_route.bus_type = :private_bus
+    assert_equal "路線バス（民間）", bus_route.bus_type_label
+
+    bus_route.bus_type = "public_bus"
+    assert_equal "路線バス（公営）", bus_route.bus_type_label
+  end
+
   test "should bus_route_bus_stops order by bus_stop_number" do
     bus_route = BusRoute.create!
     bus_route.bus_route_bus_stops << BusRouteBusStop.new(bus_stop_number: 2, bus_stop: BusStop.new(name: "2"))

--- a/test/models/bus_route_track_test.rb
+++ b/test/models/bus_route_track_test.rb
@@ -12,6 +12,12 @@ class BusRouteTrackTest < ActiveSupport::TestCase
     assert_respond_to bus_route_track, :bus_route
   end
 
+  test "should require bus_route" do
+    track = BusRouteTrack.new(gml_id: "x", coordinates: [])
+    refute track.valid?
+    assert_includes track.errors[:bus_route], "must exist"
+  end
+
   test "should coordinates round-trip through database as JSON" do
     bus_route_track = BusRouteTrack.create!(
       bus_route: bus_routes(:one),

--- a/test/models/bus_route_track_test.rb
+++ b/test/models/bus_route_track_test.rb
@@ -12,15 +12,25 @@ class BusRouteTrackTest < ActiveSupport::TestCase
     assert_respond_to bus_route_track, :bus_route
   end
 
-  test "shoud coordinates serialize to JSON" do
-    bus_route_track = BusRouteTrack.new
+  test "should coordinates round-trip through database as JSON" do
+    bus_route_track = BusRouteTrack.create!(
+      bus_route: bus_routes(:one),
+      gml_id: "track-roundtrip",
+      coordinates: [ [ 1.5, 2.5 ], [ 3.5, 4.5 ] ]
+    )
 
-    bus_route_track.coordinates = []
-    assert_equal "[]", bus_route_track.coordinates.inspect
-    assert_not_equal '"[]"', bus_route_track.coordinates.inspect
+    bus_route_track.reload
+    assert_equal [ [ 1.5, 2.5 ], [ 3.5, 4.5 ] ], bus_route_track.coordinates
+  end
 
-    bus_route_track.gml_id = []
-    assert_equal '"[]"', bus_route_track.gml_id.inspect
-    assert_not_equal "[]", bus_route_track.gml_id.inspect
+  test "should coordinates round-trip empty array" do
+    bus_route_track = BusRouteTrack.create!(
+      bus_route: bus_routes(:one),
+      gml_id: "track-empty",
+      coordinates: []
+    )
+
+    bus_route_track.reload
+    assert_equal [], bus_route_track.coordinates
   end
 end

--- a/test/models/bus_stop_test.rb
+++ b/test/models/bus_stop_test.rb
@@ -75,16 +75,11 @@ class BusStopTest < ActiveSupport::TestCase
       [ 40.7143528, -74.0059731 ], [
         {
           "postal_code" => "000-0000",
-          "formatted_address" => "日本, Test Address"
+          "formatted_address" => "日本, Test Address",
+          "address_components" => [ { "types" => [ "locality", "political" ], "long_name" => "City Name" } ]
         }
       ]
     )
-
-    class Geocoder::Result::Test
-      def address_components
-        [ { "types" => [ "locality", "political" ], "long_name" => "City Name" } ]
-      end
-    end
 
     bus_stop = BusStop.new(latitude: 40.7143528, longitude: -74.0059731)
     bus_stop.reverse_geocode
@@ -92,5 +87,35 @@ class BusStopTest < ActiveSupport::TestCase
     assert_equal "000-0000", bus_stop.postal_code
     assert_equal "City Name", bus_stop.city
     assert_equal "Test Address", bus_stop.formatted_address
+  end
+
+  test "should reverse_geocode skip city when locality is missing" do
+    Geocoder::Lookup::Test.add_stub(
+      [ 1.0, 2.0 ], [
+        {
+          "postal_code" => "111-1111",
+          "formatted_address" => "日本, Country Only Address",
+          "address_components" => [ { "types" => [ "country" ], "long_name" => "Japan" } ]
+        }
+      ]
+    )
+
+    bus_stop = BusStop.new(latitude: 1.0, longitude: 2.0)
+    bus_stop.reverse_geocode
+
+    assert_equal "111-1111", bus_stop.postal_code
+    assert_nil bus_stop.city
+    assert_equal "Country Only Address", bus_stop.formatted_address
+  end
+
+  test "should reverse_geocode do nothing when no results" do
+    Geocoder::Lookup::Test.add_stub([ 9.0, 9.0 ], [])
+
+    bus_stop = BusStop.new(latitude: 9.0, longitude: 9.0)
+    bus_stop.reverse_geocode
+
+    assert_nil bus_stop.postal_code
+    assert_nil bus_stop.city
+    assert_equal "", bus_stop.formatted_address
   end
 end

--- a/test/models/place_test.rb
+++ b/test/models/place_test.rb
@@ -24,4 +24,22 @@ class PlaceTest < ActiveSupport::TestCase
     assert spot === place.spot
     assert spot.verify
   end
+
+  test "should formatted_address strip leading '日本, '" do
+    spot = Minitest::Mock.new
+    spot.expect :formatted_address, "日本, 東京都千代田区"
+
+    place = Place.new spot
+    assert_equal "東京都千代田区", place.formatted_address
+    assert spot.verify
+  end
+
+  test "should formatted_address leave string unchanged when no '日本, ' prefix" do
+    spot = Minitest::Mock.new
+    spot.expect :formatted_address, "Tokyo, Japan"
+
+    place = Place.new spot
+    assert_equal "Tokyo, Japan", place.formatted_address
+    assert spot.verify
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -20,19 +20,23 @@ class ActiveSupport::TestCase
   # `GooglePlaces::Client` を一時的にモックに差し替えるブロックヘルパー。
   # `remove_const` を直接書くと差し替えが残って後続テストを汚染するため、
   # ensure で必ず元の定数を復元する。
+  #
+  # `Client.new` はコントローラの cache 判定の前に毎回呼ばれるため、HTTP リクエストの
+  # 回数だけインスタンス化されうる。検証したいのは `spots_by_query` の呼び出しなので、
+  # `new` は何度呼ばれても同じ instance_mock を返す class double で受ける。
   def with_google_places_stub(spots:)
     instance_mock = Minitest::Mock.new
     instance_mock.expect :spots_by_query, spots, [ String ], lat: Float, lng: Float, radius: Integer, language: String
-    class_mock = Minitest::Mock.new
-    class_mock.expect :new, instance_mock, [ String ]
+
+    class_double = Object.new
+    class_double.define_singleton_method(:new) { |_api_key| instance_mock }
 
     original = GooglePlaces::Client
     GooglePlaces.send(:remove_const, :Client)
-    GooglePlaces.const_set(:Client, class_mock)
+    GooglePlaces.const_set(:Client, class_double)
     begin
       yield
       instance_mock.verify
-      class_mock.verify
     ensure
       GooglePlaces.send(:remove_const, :Client)
       GooglePlaces.const_set(:Client, original)


### PR DESCRIPTION
## 概要

前 PR #33 の延長で、model と controller の挙動検証を 7 件追加します。観点ごとに 1 コミットに分けてあります。

## 含まれる変更（コミット順）

1. **`reverse_geocode` の分岐網羅** (`29e0ca2`)
   - 結果ゼロ件 / `locality, political` 無し の 2 分岐を追加
   - 既存テストの `class Geocoder::Result::Test` 再オープンを廃止し、stub データの `"address_components"` キー経由でモンキーパッチ無しに整理
2. **`BusRouteTrack` JSON ラウンドトリップに差し替え** (`4c7bde6`)
   - `[].inspect` の文字列比較で済ませていた謎テストを、`create! → reload → coordinates` の真の round-trip に置き換え
3. **`BusRoutesController#show` の停留所順検証** (`d5b6e23`)
   - `bus_stop_number = 2` を先に作成、`= 1` を後に作成しても、HTML 上では `1` が先に登場することを `body.index` で確認
4. **`Place#formatted_address` の `"日本, "` 除去** (`d45de49`)
   - 実装の `sub("日本, ", "")` が動いていることを正常系・否定系の両方で固定
5. **検索キャッシュの動作検証** (`30c7eaa`)
   - 同じクエリで 2 回叩いても GooglePlaces API は 1 回しか呼ばれないことを `Rails.cache` を `:memory_store` に差し替えた上で検証
   - 関連して `with_google_places_stub` ヘルパーを `Client.new` 任意回数許容に修正
6. **controller の中身 + 空文字 q の挙動** (`e34e67e`)
   - `AboutController` / `HomeController` に最低限の `assert_select`
   - `BusStopsController#index` に `q=""` (truthy なので keyword 分岐に入って全件マッチする) という暗黙仕様を明文化
7. **belongs_to required と enum セッタ多態性** (`2ce61d9`)
   - `BusRouteBusStop` / `BusRouteTrack` の `belongs_to` 必須をバリデーションエラーで固定
   - `BusRoute#bus_type_label` がシンボル / 文字列セッタでも同じラベルを返すことを確認

## テスト結果（ローカル）

`bin/rails test:all` で 60 runs / 156 assertions / 0 failures。Line Coverage: 94.59%。

## Test plan

- [x] `docker-compose run --rm app bin/rails test:all` がローカルでグリーン
- [x] CI の `test` ジョブがグリーン
- [x] CI の `system-test` ジョブがグリーン