### PR TITLE
Replace jquery_ujs with rails-ujs

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -11,7 +11,7 @@
 // about supported directives.
 //
 //= require jquery
-//= require jquery_ujs
+//= require rails-ujs
 //= require bootstrap-sprockets
 //= require underscore-min
 //= require gmaps/google


### PR DESCRIPTION
## 概要

`app/assets/javascripts/application.js` の Sprockets manifest で読み込んでいた `jquery_ujs` を、Rails 5.2 以降の標準である jQuery 非依存の `rails-ujs`（actionview に同梱）に置き換えます。

## なぜ

- chi-bus.jp は Rails 8.1 上で動いているが、UJS 系統の取り込みは jQuery 時代の `jquery_ujs` のままだった
- Rails 5.2-7 の標準は `rails-ujs` で、Rails 8.1 は Turbo がさらに進んだ標準
- 同じ作者の別プロジェクト (personnel_assessment) は既に `rails-ujs` に移行済みで、整合を取りたい
- Turbo への移行は scope が大きい（既存 Sprockets / jQuery と並走しているプロジェクトに今 Turbo を足すと挙動の確認範囲が広がる）ため、本 PR では rails-ujs 段階までに留める

## 変更内容

`application.js` 内の Sprockets ディレクティブを 1 行差し替え:

```diff
-//= require jquery_ujs
+//= require rails-ujs
```

`rails-ujs` は actionview 同梱なので Gemfile の変更は不要。

## 機能差分の確認

`grep -rn "data-remote\|data-confirm\|data-method\|data-disable-with" app/` で **該当 0 件**。UJS 機能（リンクの POST 化、確認ダイアログ等）は実コードで一切使っていないため、置換による挙動差は出ない。

## あえてやっていないこと（後続 PR）

- `gem "jquery-rails"` 本体の削除
  - common.js とトップページの inline script が `$(...)` で jQuery を直接使っているため、jQuery 自体はまだ必要
  - `common.js` を vanilla JS にリファクタした後に削除可能
- `application.js` から `//= require bootstrap-sprockets` の削除
  - `data-toggle` / `data-target` 等 Bootstrap JS コンポーネントは views で 0 件 → 実質不使用なので削除候補
- Turbo への移行（Rails 7+ 標準）

## テスト結果

`bin/rails test:all` で 60 runs / 156 assertions / 0 failures。