### PR TITLE
Remove stale CI / coverage / code climate badges from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# chi-bus.jp [![Build Status](https://travis-ci.org/yamamuteki/chi-bus.jp.svg?branch=master)](https://travis-ci.org/yamamuteki/chi-bus.jp) [![Coverage Status](https://coveralls.io/repos/github/yamamuteki/chi-bus.jp/badge.svg?branch=master)](https://coveralls.io/github/yamamuteki/chi-bus.jp?branch=master) [![Code Climate](https://codeclimate.com/github/yamamuteki/chi-bus.jp/badges/gpa.svg)](https://codeclimate.com/github/yamamuteki/chi-bus.jp)
+# chi-bus.jp
 
 千葉・東京・神奈川・埼玉（および茨城・栃木・群馬の一部）を対象とした、バス停と路線情報を提供する Web サービスです。
 


### PR DESCRIPTION
## 概要

README 冒頭に並んでいた 3 つのバッジを削除します。いずれも現状と紐付いていません。

- **Travis CI**: `travis-ci.org` は 2022 年に閉鎖。CI は GitHub Actions (`.github/workflows/ci.yml`) に移行済み
- **Coveralls**: 過去に連携していた形跡はあるが、現在の CI から coverage を送る経路は無い
- **Code Climate**: 同様に連携が切れている

リンク切れのバッジを残しておく利点が無いため一旦全て外します。GitHub Actions のステータスバッジを置きたくなったときは別途追加します。