### PR TITLE
Refactor common.js and offload layout sizing to CSS

### DIFF
--- a/app/assets/javascripts/common.js
+++ b/app/assets/javascripts/common.js
@@ -1,98 +1,130 @@
+// 全画面共通の挙動をまとめたスクリプト。
+// IIFE（即時実行関数）でグローバル汚染を防ぎつつ、ページ内のクリックやリサイズに対する
+// jQuery のイベントハンドラをまとめて登録している。
 (function() {
-  function listResize() {
-    if (!$(".list-window").length) return;
-    $(".map").height($(window).height() - 125);
-    if ($(window).width() < 768 || window.matchMedia("print").matches) {
-      $(".list-window").height("auto");
-      $(".list-window").css("overflow-y", "visible");
-    } else {
-      var listWindowHeight = $(window).height() - $(".list-window").offset().top - 11;
-      $(".list-window").height(listWindowHeight);
-      $(".list-window").css("overflow-y", "scroll");
+  // ---------------------------------------------------------------------------
+  // セレクタ定数
+  // 同じセレクタを複数箇所で書くと typo の温床になるので、上で一度だけ定義しておく。
+  // ---------------------------------------------------------------------------
+  const SELECTOR_GEOLOCATION_BUTTON = "button[data-geolocation]";
+  const SELECTOR_SEARCH_MAP_CENTER = "a[data-search-map-center]";
+  const SELECTOR_BUS_ROUTE_LINK = "a[data-bus-route-link]";
+  const SELECTOR_BUS_STOP_LINK = "a[data-bus-stop-link]";
+
+  // ---------------------------------------------------------------------------
+  // マップ図形のスタイル定数
+  // Google Maps の Polyline / Marker は SVG/Canvas 描画なので CSS クラスは効かない。
+  // 代わりに「JS のオプション値オブジェクト」を名前付きで切り出して使い回す。
+  // ---------------------------------------------------------------------------
+  // 路線（Polyline）のスタイル
+  const POLYLINE_STYLE_NORMAL = {
+    strokeColor: "#00f",   // 青
+    strokeOpacity: 0.5,    // 半透明
+    zIndex: 0
+  };
+  const POLYLINE_STYLE_HIGHLIGHTED = {
+    strokeColor: "#c00",   // 赤
+    strokeOpacity: 1.0,    // 不透明
+    zIndex: 1              // 他の路線の上に重ねる
+  };
+
+  // ---------------------------------------------------------------------------
+  // 現在地検索ボタン: navigator.geolocation で緯度経度を取って /bus_stops?position=... へ遷移
+  // ---------------------------------------------------------------------------
+  function handleGeolocationClick(event) {
+    // 同じフォーム内のキーワード入力 (#q) に値があるなら、ユーザーはキーワード検索を意図している。
+    // その場合は現在地取得をスキップしてフォームを通常送信させる。
+    const $form = $(this).closest("form");
+    if ($form.find("#q").val() !== "") return;
+
+    event.preventDefault();
+
+    if (!navigator.geolocation) {
+      console.warn("Navigator.geolocation not supported.");
+      return;
     }
+
+    navigator.geolocation.getCurrentPosition(
+      function(position) {
+        const lat = position.coords.latitude;
+        const lng = position.coords.longitude;
+        window.location.href = "/bus_stops?position=" + lat + "," + lng;
+      },
+      function(err) {
+        console.warn("ERROR(" + err.code + "): " + err.message);
+      }
+    );
   }
 
-  $(function() {
-    $("button[data-geolocation]").click(function(e) {
-      // q が入力されているときは通常のキーワード検索なので位置情報取得をスキップ
-      if ($(this).closest("form").find("#q").val() !== "") return;
-      if (navigator.geolocation) {
-        navigator.geolocation.getCurrentPosition(function(position) {
-          var lat = position.coords.latitude;
-          var long = position.coords.longitude;
-          window.location.href = "/bus_stops?position=" + lat + "," + long;
-        }, function(err) {
-          console.warn("ERROR(" + err.code + "): " + err.message);
-        });
-      } else {
-        console.warn("Navigator.geolocation not supported.");
-      }
-      return false;
-    });
-  });
+  // ---------------------------------------------------------------------------
+  // 「この地図の中心で検索」リンク: 表示中のマップの中心座標で検索画面へ遷移
+  // ---------------------------------------------------------------------------
+  function handleSearchMapCenterClick(event) {
+    event.preventDefault();
+    // handler は application.js の drawMap() 内で生成されるグローバル変数。
+    const center = handler.getMap().getCenter();
+    window.location.href = "/bus_stops?position=" + center.lat() + "," + center.lng();
+  }
 
-  $(function() {
-    $("a[data-search-map-center]").click(function(e) {
-      var center = handler.getMap().getCenter();
-      var lat = center.lat();
-      var long = center.lng();
-      window.location.href = "/bus_stops?position=" + lat + "," + long;
-      return false;
-    });
-  });
+  // ---------------------------------------------------------------------------
+  // ホバー連動: リスト項目とマップ上の図形（polyline / marker）を同期させる
+  // ---------------------------------------------------------------------------
+  // data-* 属性に入っている id と一致する Gmaps オブジェクトを「全部」返す。
+  // application.js は 1 つの bus_route に対して複数の polyline（tracks の数だけ）を作ることがあり、
+  // 同じ id を共有している。ホバー時はそれら全部を一括で強調表示したいので、find（最初の 1 件）ではなく filter を使う。
+  // marker は 1 つの bus_stop につき 1 つだけだが、コードを揃えるため同じ関数で扱う。
+  // data 属性は文字列で取り出されるので "+ ''" で文字列化して比較している。
+  function findMapObjectsById(collection, id) {
+    return (collection || []).filter(function(obj) { return obj.id + "" === id; });
+  }
 
-  $(function() {
-    listResize();
-    $(window).resize(function() {
-      listResize();
-    });
-    var mql = window.matchMedia("print");
-    mql.addListener(function(mql) {
-      if (mql.matches) {
-        listResize();
-      }
-    });
-  });
+  // document.body.meta は drawMap() が呼ばれて初めて設定される。
+  // マップのないページ（about など）では未定義になるので、安全側で空オブジェクトに寄せる。
+  function getMapMeta() {
+    return document.body.meta || {};
+  }
 
-  $(function() {
-    function setPolylineOptions(object, strokeColor, strokeOpacity, zIndex) {
-      var id = $(object).attr("data-bus-route-link");
-      if (!document.body.meta.polylines) return;
-      for (var i = 0; i < document.body.meta.polylines.length; i++) {
-        var polyline = document.body.meta.polylines[i];
-        if (polyline.id + "" === id) {
-          polyline.getServiceObject().setOptions({
-            strokeColor: strokeColor,
-            strokeOpacity: strokeOpacity,
-            zIndex: zIndex
-          });
-        }
-      }
-    }
-    $("a[data-bus-route-link]").on("mouseenter", function(e) {
-      setPolylineOptions(this, "#c00", 1.0, 1);
+  // 路線リンクのホバー: 対応する polyline 群を強調表示／元に戻す
+  function setBusRouteHighlight($link, highlighted) {
+    const id = $link.attr("data-bus-route-link");
+    const polylines = findMapObjectsById(getMapMeta().polylines, id);
+    const style = highlighted ? POLYLINE_STYLE_HIGHLIGHTED : POLYLINE_STYLE_NORMAL;
+    polylines.forEach(function(polyline) {
+      polyline.getServiceObject().setOptions(style);
     });
-    $("a[data-bus-route-link]").on("mouseleave click", function(e) {
-      setPolylineOptions(this, "#00f", 0.5, 0);
-    });
-  });
+  }
 
-  $(function() {
-    function setMarkerAnimation(object, animation) {
-      var id = $(object).attr("data-bus-stop-link");
-      if (!document.body.meta.markers) return;
-      for (var i = 0; i < document.body.meta.markers.length; i++) {
-        var marker = document.body.meta.markers[i];
-        if (marker.id + "" === id) {
-          marker.getServiceObject().setAnimation(animation);
-        }
-      }
-    }
-    $("a[data-bus-stop-link]").on("mouseenter", function(e) {
-      setMarkerAnimation(this, google.maps.Animation.BOUNCE);
+  // 停留所リンクのホバー: 対応する marker をバウンスさせる／止める
+  function setBusStopAnimation($link, animation) {
+    const id = $link.attr("data-bus-stop-link");
+    const markers = findMapObjectsById(getMapMeta().markers, id);
+    markers.forEach(function(marker) {
+      marker.getServiceObject().setAnimation(animation);
     });
-    $("a[data-bus-stop-link]").on("mouseleave click", function(e) {
-      setMarkerAnimation(this, null);
+  }
+
+  // ---------------------------------------------------------------------------
+  // DOMContentLoaded 後に各種イベントハンドラを登録
+  // ---------------------------------------------------------------------------
+  $(function() {
+    // 検索系
+    $(document).on("click", SELECTOR_GEOLOCATION_BUTTON, handleGeolocationClick);
+    $(document).on("click", SELECTOR_SEARCH_MAP_CENTER, handleSearchMapCenterClick);
+
+    // 路線リンク ↔ polyline の連動
+    $(document).on("mouseenter", SELECTOR_BUS_ROUTE_LINK, function() {
+      setBusRouteHighlight($(this), true);
+    });
+    $(document).on("mouseleave", SELECTOR_BUS_ROUTE_LINK, function() {
+      setBusRouteHighlight($(this), false);
+    });
+
+    // 停留所リンク ↔ marker の連動
+    $(document).on("mouseenter", SELECTOR_BUS_STOP_LINK, function() {
+      setBusStopAnimation($(this), google.maps.Animation.BOUNCE);
+    });
+    $(document).on("mouseleave", SELECTOR_BUS_STOP_LINK, function() {
+      setBusStopAnimation($(this), null);
     });
   });
 })();

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -89,8 +89,40 @@ h1, .h1, h2, .h2, h3, .h3 {
 
 .map {
   width: 100%;
-  height: calc(100vh - 120px); /* iPad対応のためJSで調整 */
+  // dvh はモバイル Safari のアドレスバー表示状態に追従するため、100vh で起きていた「実画面より大きくなる」問題が出ない。
+  height: calc(100dvh - 120px);
   margin-bottom: 10px;
+}
+
+/*
+ * バス停・路線一覧の縦スクロール枠。
+ * - PC（768px以上）は右カラムを flex で組み、ヘッダ（h3 など）の残り高さをリスト枠に与えて内部スクロール
+ * - スマホ・印刷時はページ全体を素直に流したいので、高さを固定せず overflow-y: visible
+ */
+.list-window {
+  overflow-y: visible;
+}
+
+@media (min-width: 768px) {
+  // .list-window を含む右カラムを flex コンテナにして、リスト枠が縦の残りスペースを吸収するようにする。
+  // :has() セレクタを使うことで、ビュー側に追加クラスを付けずに「リスト枠を持つ列」だけを対象にできる。
+  .col-sm-4:has(> .list-window) {
+    height: calc(100dvh - 120px); // マップと同じ高さに揃える
+    display: flex;
+    flex-direction: column;
+  }
+
+  .list-window {
+    flex: 1;          // 残り高さを自動で吸収
+    overflow-y: auto; // はみ出した分だけ内部スクロール
+    min-height: 0;    // flex 子要素が縮める用のおまじない（無いと縮まずに親をはみ出す）
+  }
+}
+
+@media print {
+  .list-window {
+    overflow-y: visible;
+  }
 }
 
 .search-box {


### PR DESCRIPTION
## 概要

`app/assets/javascripts/common.js` をリーダビリティ重視で書き直し、レイアウト調整は CSS に寄せた。

## 変更内容

### JS 側
- IIFE の中身を「セレクタ定数 → スタイル定数 → 関数定義 → 登録」の階層に整理し、各関数に日本語コメントを付与
- `adjustLayout()` / `listResize()` および resize / matchMedia(print) リスナーを削除（CSS に移管）
- ホバー時の不要な `click` ハンドラを削除（ページ遷移で DOM が破棄されるため強調を戻す必要なし）
- `Array#filter` + `forEach` で同一 id の polyline 群（tracks 単位で複数生成される）をまとめて強調表示
- Polyline のスタイル値を `POLYLINE_STYLE_NORMAL` / `POLYLINE_STYLE_HIGHLIGHTED` 定数に切り出し
- 全 `var` を `const` に置換

### CSS 側
- `.map` の高さを `calc(100dvh - 120px)` に変更。モバイル Safari のアドレスバー伸縮に CSS だけで追従するため、JS の上書きを廃止
- `.list-window` を含む右カラムを `:has(> .list-window)` で限定して flex コンテナにし、リスト枠が残り高さを自動吸収する形に。`offset.top` ベースの JS 計算が不要になった
- 印刷時の `overflow-y: visible` をメディアクエリで定義

## Test plan

- [ ] PC 幅 (768px 以上): マップとリスト枠の下端が揃い、リスト枠内だけがスクロールする
- [ ] スマホ幅 (768px 未満): マップとリストが縦に並び、ページ全体がスクロールする
- [ ] iOS Safari: アドレスバー伸縮時にマップ下端が画面外にはみ出さない
- [ ] 「現在地検索」ボタンが動作する（キーワード入力時はキーワード検索になる）
- [ ] マップ下「中心周辺を検索」リンクが動作する
- [ ] 路線リンクをホバーすると対応する polyline が赤く強調される（複数 track でも全枝が赤くなる）
- [ ] 停留所リンクをホバーすると対応する marker がバウンスする
- [ ] 印刷プレビューでリスト枠が縦に流れる

🤖 Generated with [Claude Code](https://claude.com/claude-code)