### PR TITLE
Add Japanese comments to remaining rake tasks

### DIFF
--- a/lib/tasks/bus_stop_number.rake
+++ b/lib/tasks/bus_stop_number.rake
@@ -1,24 +1,44 @@
+# 路線内のバス停の「順番」(BusRouteBusStop#bus_stop_number) を生成・永続化する rake タスク群。
+#
+# generate: DB 上の路線軌跡 (BusRouteTrack) と停留所座標から空間計算で順序を割り出して DB に書き込む。
+# dump:     DB の bus_stop_number を db/bus_stop_number.json に書き出す（永続化）。
+# restore:  db/bus_stop_number.json から DB に書き戻す。
+#
+# generate は計算結果が再現しない（座標の浮動小数点比較や巡回順序に依存して順序が変わりうる）ため、
+# 通常のセットアップでは generate ではなく restore を使う、というのが運用ルール。
+# CLAUDE.md の「bus_stop_number:generate は再生成すると順序が変わりうるため、運用上は既存 JSON を尊重する原則」を参照。
 namespace :bus_stop_number do
   desc "Generate bus stop number"
   task generate: :environment do
+    # BusRoute ごとに、その路線の軌跡に沿って近接停留所に 1 から順番を振る。
     progress = ProgressBar.create(title: "Generate", total: BusRoute.count, format: "%t: %J%% |%B|")
     ActiveRecord::Base.transaction do
+      # まず既存の番号を全件クリア（中途半端な状態が残っていても再計算できるように）
       BusRouteBusStop.update_all(bus_stop_number: nil)
+
       BusRoute.find_each do |bus_route|
         index = 0
         bus_route_bus_stops = bus_route.bus_route_bus_stops
+
+        # 軌跡 (Track) を「最初の座標の経度」で並べる。1 路線が複数の Track に分かれている場合に、
+        # おおむね西から東へ巡る順序にするための簡易ソート（厳密な進行方向判定はしない）。
         bus_route.bus_route_tracks.sort_by { |t| t.coordinates[0][1] }.each do |track|
+          # 軌跡上の各座標について、近くにある未採番の停留所を探して順番を振っていく。
           track.coordinates.each do |coordinate|
-            latitude = coordinate[0]
+            latitude  = coordinate[0]
             longitude = coordinate[1]
+
             bus_route_bus_stops.each do |bus_route_bus_stop|
-              next if bus_route_bus_stop.bus_stop_number
+              next if bus_route_bus_stop.bus_stop_number # 既に番号が振られた停留所はスキップ
+
               bus_stop = bus_route_bus_stop.bus_stop
+              # 緯度経度をピタゴラス的に二乗距離として比較（厳密な球面距離ではない簡易判定）。
+              # 0.000001 ≒ 0.001 度² → 距離としては約 100m 以内（緯度方向は約 111m/度なので妥当）。
               distance = (bus_stop.latitude - latitude) ** 2 + (bus_stop.longitude - longitude) ** 2
               if distance < 0.000001 then
                 bus_route_bus_stop.bus_stop_number = index += 1
                 bus_route_bus_stop.save
-                break
+                break # この座標で見つかったら次の軌跡座標へ
               end
             end
           end
@@ -30,6 +50,8 @@ namespace :bus_stop_number do
 
   desc "Dump bus stop number"
   task dump: :environment do
+    # DB の BusRouteBusStop を全件走査し、id と bus_stop_number のペアを JSON に書き出す。
+    # generate の結果を git にコミット可能な形（db/bus_stop_number.json）で永続化するための工程。
     progress = ProgressBar.create(title: "Dump", total: BusRouteBusStop.count, format: "%t: %J%% |%B|")
     File.write("db/bus_stop_number.json", JSON.pretty_generate(
       BusRouteBusStop.find_each.map do |bus_route_bus_stop|
@@ -44,6 +66,8 @@ namespace :bus_stop_number do
 
   desc "Restore bus stop number"
   task restore: :environment do
+    # db/bus_stop_number.json を読み込み、各 BusRouteBusStop の bus_stop_number を復元する。
+    # 通常のセットアップでは generate を回さずにこちらを使う（generate は順序が変わりうるため）。
     records = JSON.parse(File.read("db/bus_stop_number.json"))
     progress = ProgressBar.create(title: "Restore", total: records.count, format: "%t: %J%% |%B|")
     ActiveRecord::Base.transaction do

--- a/lib/tasks/geocode.rake
+++ b/lib/tasks/geocode.rake
@@ -1,9 +1,24 @@
+# バス停の住所情報（郵便番号・市区町村・整形済み住所）を Google の逆ジオコーディング API で取得し、
+# DB と JSON に永続化する rake タスク群。
+#
+# generate: Google API を呼んで BusStop に住所情報を埋める（外部 API 課金が発生する重い処理）。
+# dump:     DB の住所情報を db/geocording_data.json に書き出す（永続化）。
+# restore:  db/geocording_data.json から DB に書き戻す。
+#
+# 通常のセットアップでは generate ではなく restore を使う（API コスト・実行時間の節約）。
 namespace :geocode do
   desc "Generate geocording data"
   task generate: :environment do
+    # formatted_address が未設定の停留所のみ対象。これにより:
+    # - 初回セットアップ時は全件処理
+    # - 中断 → 再実行時は未処理分から続けられる
+    # - 既存停留所への再実行（API 二重課金）を防げる
     query = BusStop.where(formatted_address: nil)
     progress = ProgressBar.create(title: "Generate", total: query.count, format: "%t: %J%% |%B|")
     query.find_each.each do |bus_stop|
+      # Geocoder gem の reverse_geocode が、緯度経度を逆引きして
+      # postal_code / city / formatted_address を埋めてくれる。
+      # 対応マッピングは BusStop モデルの reverse_geocoded_by ブロックを参照。
       bus_stop.reverse_geocode
       bus_stop.save!
       progress.increment
@@ -12,6 +27,8 @@ namespace :geocode do
 
   desc "Dump geocording data"
   task dump: :environment do
+    # DB の住所情報を JSON に書き出して永続化する。
+    # generate の結果を git にコミット可能な形にして、運用時は restore で再現する。
     progress = ProgressBar.create(title: "Dump", total: BusStop.count, format: "%t: %J%% |%B|")
     File.write("db/geocording_data.json", JSON.pretty_generate(
       BusStop.find_each.map do |bus_stop|
@@ -28,6 +45,8 @@ namespace :geocode do
 
   desc "Restore geocording data"
   task restore: :environment do
+    # db/geocording_data.json を読み込み、各 BusStop の住所情報を復元する。
+    # 通常のセットアップではこちらを使い、Google API への問い合わせを避ける。
     records = JSON.parse(File.read("db/geocording_data.json"))
     progress = ProgressBar.create(title: "Restore", total: records.count, format: "%t: %J%% |%B|")
     ActiveRecord::Base.transaction do

--- a/lib/tasks/keyword.rake
+++ b/lib/tasks/keyword.rake
@@ -1,9 +1,28 @@
+# 検索用キーワード (BusStop#keyword) を生成・永続化する rake タスク群。
+#
+# generate: kakasi で停留所名を漢字 → ローマ字 / ひらがな / カタカナに変換し、空白区切りで連結して保存。
+#           この文字列が `lower(...) LIKE lower(...)` の検索対象となり、漢字・かな・ローマ字の
+#           どの入力でもヒットするようになる（BusStopsController#index の検索ロジック）。
+# dump:     DB の keyword を db/keywords.json に書き出す（永続化）。
+# restore:  db/keywords.json から DB に書き戻す。
+#
+# generate は kakasi_parser gem を要求する。Gemfile では通常コメントアウトされており、
+# 再生成時のみ有効化する運用（CLAUDE.md 参照）。通常のセットアップでは restore を使う。
 namespace :keyword do
   desc "Generate keywords"
   task generate: :environment do
     progress = ProgressBar.create(title: "Generate", total: BusStop.count, format: "%t: %J%% |%B|")
     ActiveRecord::Base.transaction do
       BusStop.find_each.each do |bus_stop|
+        # kakasi のオプション解説（末尾の文字が「変換先」、それより前の大文字が「変換元」）:
+        #   -Ja -Ha -Ka -ka -Ea -p
+        #     漢字(J) / ひらがな(H) / カタカナ(K) / 半角カナ(k) / ASCII記号(E) を全て ASCII (a) = ローマ字に
+        #   -JH -aH -KH -kH -EH -p
+        #     全部ひらがな(H)に
+        #   -JK -aK -HK -kK -EK -p
+        #     全部カタカナ(K)に
+        #   -p は曖昧な漢字読みの全候補を出力する（読みのバリエーションをまとめてヒットさせるため）
+        # `.delete("^")` は kakasi が候補区切りに出す `^` を取り除いて 1 つのフラットな文字列にする処理。
         keyword = [
           bus_stop.name,
           KakasiParser.kakasi("-Ja -Ha -Ka -ka -Ea -p", bus_stop.name).join(" ").delete("^"),
@@ -18,6 +37,8 @@ namespace :keyword do
 
   desc "Dump keywords"
   task dump: :environment do
+    # DB の keyword を JSON に書き出して永続化する。
+    # generate の結果を git にコミット可能な形にして、運用時は restore で再現する。
     progress = ProgressBar.create(title: "Dump", total: BusStop.count, format: "%t: %J%% |%B|")
     File.write("db/keywords.json", JSON.pretty_generate(
       BusStop.find_each.map do |bus_stop|
@@ -32,6 +53,8 @@ namespace :keyword do
 
   desc "Restore keywords"
   task restore: :environment do
+    # db/keywords.json を読み込み、各 BusStop の keyword を復元する。
+    # 通常のセットアップではこちらを使い、kakasi_parser gem の有効化を避ける。
     records = JSON.parse(File.read("db/keywords.json"))
     progress = ProgressBar.create(title: "Restore", total: records.count, format: "%t: %J%% |%B|")
     ActiveRecord::Base.transaction do


### PR DESCRIPTION
## 概要

`lib/tasks/` 配下の残り 3 つの rake タスク群に日本語コメントを追加した。コードロジックは変更なし、コメントのみ。

## 変更内容

### bus_stop_number.rake
- generate / dump / restore の役割と運用原則（再生成は順序が変わりうるため通常は restore を使う）を冒頭に明示
- 軌跡 (Track) を最初の座標の経度で並べる意図を補足
- `distance < 0.000001` が約 100m 相当である根拠を追記
- 既存番号を `update_all(bus_stop_number: nil)` でクリアする目的を明示

### geocode.rake
- `formatted_address: nil` で絞り込んでいる意図（中断再開・API 二重課金防止）を明示
- 通常運用では restore を使う方針を冒頭に記載
- Geocoder gem の `reverse_geocode` がモデル側の `reverse_geocoded_by` ブロックと連動することを補足

### keyword.rake
- kakasi のオプション解説を追加
  - `-J` / `-H` / `-K` / `-k` / `-E` が変換元、末尾の文字 (`a` / `H` / `K`) が変換先
  - `-p` は曖昧読みの全候補を出力するオプション
- `.delete(\"^\")` の意図（候補区切り文字の除去）を補足
- kakasi_parser gem が通常コメントアウトされていることに言及

## Test plan

- [ ] 各 rake task が `bin/rails -T` で従来通り認識される
- [ ] コメント追加のみなので動作変更なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)