### PR TITLE
Drop ProgressBar to make data:generate 7x faster (4:41 -> 0:38)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -96,3 +96,5 @@ gem "rails-erd", group: :development
 gem "kakasi_parser", group: :development
 # kakasi gem の実行時依存（Ruby 4.0 で default gem から外れるため明示）
 gem "fiddle", group: :development
+# data:profile タスクで使用 (sampling profiler、低オーバーヘッド)
+gem "stackprof", require: false, group: :development

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -405,6 +405,7 @@ GEM
       net-sftp (>= 2.1.2)
       net-ssh (>= 2.8.0)
       ostruct
+    stackprof (0.2.28)
     stimulus-rails (1.3.4)
       railties (>= 6.0.0)
     stringio (3.2.0)
@@ -483,6 +484,7 @@ DEPENDENCIES
   solid_cable
   solid_cache
   solid_queue
+  stackprof
   stimulus-rails
   terser
   thruster

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -30,9 +30,6 @@ class DataGenerator
   ROUTE_XML_FORMAT = "db/N07-11_%s.xml".freeze
   STOP_XML_FORMAT  = "db/P11-10_%s-jgd-g.xml".freeze
 
-  # ProgressBar の表示フォーマット。タイトル + パーセント + バー
-  PROGRESS_FORMAT = "%t: %J%% |%B|".freeze
-
   def initialize
     @now = Time.zone.now
 
@@ -83,7 +80,6 @@ class DataGenerator
   #   Float#to_s（最短ラウンドトリップ表現）を使ってサイズを抑える。
   def extract_tracks(doc, xml_path, code)
     nodes = doc.css("Curve")
-    progress = ProgressBar.create(title: "Tracks #{code}", total: nodes.count, format: PROGRESS_FORMAT)
     nodes.each do |node|
       gml_id = "#{xml_path}/#{node['id']}"
       coordinates = parse_coordinates(node.at("posList").text)
@@ -100,8 +96,8 @@ class DataGenerator
       }
       @track_id_by_gml[gml_id] = track_id
       @track_coords_by_id[track_id] = simplified
-      progress.increment
     end
+    puts "  Tracks #{code}: #{nodes.size} curves"
   end
 
   # BusRoute 要素 = 路線属性。
@@ -109,7 +105,6 @@ class DataGenerator
   # ・brt[href] が指す Curve（= bus_route_tracks の行）の bus_route_id を逆向きに埋める
   def extract_routes(doc, xml_path, code)
     nodes = doc.css("BusRoute")
-    progress = ProgressBar.create(title: "Routes #{code}", total: nodes.count, format: PROGRESS_FORMAT)
     nodes.each do |node|
       attrs = {
         bus_type:          node.at("bsc").text.to_i,
@@ -127,8 +122,8 @@ class DataGenerator
       if (track_id = @track_id_by_gml[track_gml])
         @bus_route_tracks[track_id - 1][:bus_route_id] = route_id
       end
-      progress.increment
     end
+    puts "  Routes #{code}: #{nodes.size} routes"
   end
 
   # 既存の同一属性 route があればその id を返し、無ければ新規作成して id を返す。
@@ -173,12 +168,11 @@ class DataGenerator
     pos_hash = build_position_index(doc)
 
     nodes = doc.css("BusStop")
-    progress = ProgressBar.create(title: "Stops #{code}", total: nodes.count, format: PROGRESS_FORMAT)
     nodes.each do |node|
       bs_id = create_bus_stop(node, pos_hash, prefecture)
       link_stop_to_routes(node, bs_id)
-      progress.increment
     end
+    puts "  Stops #{code}: #{nodes.size} stops"
   end
 
   # Point 要素の id → 緯度経度文字列の対応表。
@@ -315,12 +309,31 @@ namespace :data do
   # COPY 文の対象テーブル。順序は外部キー依存順（先に親、最後に子）。
   TABLES = %w[bus_routes bus_route_tracks bus_stops bus_route_bus_stops].freeze
 
+  desc "Profile data:generate via stackprof (writes tmp/data_generate.stackprof)"
+  task profile: :environment do
+    require "nokogiri"
+    require "simplify_rb"
+    require "csv"
+    require "stackprof"
+
+    $stdout.sync = true
+    out = "tmp/data_generate.stackprof"
+    StackProf.run(mode: :wall, out: out, interval: 1000) do
+      DataGenerator.new.run
+    end
+    puts ""
+    puts "Profile saved to #{out}"
+    puts "View top by self time:   bundle exec stackprof #{out} --text --limit 30"
+    puts "View top by total time:  bundle exec stackprof #{out} --text --total --limit 30"
+  end
+
   desc "Generate db/data/*.csv from XML sources"
   task generate: :environment do
     require "nokogiri"
     require "simplify_rb"
     require "csv"
 
+    $stdout.sync = true
     DataGenerator.new.run
   end
 


### PR DESCRIPTION
## Summary

- data:generate (4 分 41 秒) の所要時間のうち **72.8% が ProgressBar の \`tput cols\` 外部コマンド呼び出し** に費やされていた。docker-compose run のような非 TTY 環境では、ProgressBar が端末幅を取得しに行くたびに \`sh -c tput cols 2>/dev/null\` を fork し、これが約 11 万回 (Curve 26862 + BusRoute 26862 + BusStop 53025) 発生していた。
- ProgressBar.create / progress.increment をすべて削除し、代わりに各都道府県完了時に件数のサマリ行を puts する。data:generate / data:profile に \`\$stdout.sync = true\` を入れて、非 TTY 環境でも puts が即時 flush されるようにする。
- 効果: **4 分 41 秒 → 38.5 秒 (約 7.3 倍高速化)**。
- 副産物として stackprof gem (development) と data:profile タスクを追加。今後の data:generate / 別タスクのチューニングに再利用できる。

## 背景

Issue 起因は無く、開発時の data:generate が 4 分 41 秒かかるのを高速化しようとしたところ、stackprof でプロファイルしたら主犯が ProgressBar の外部コマンド呼び出しだったことが判明。中間 CSV 化や並列化を試す前に、プロファイルでボトルネックを特定する重要性を確認できた事例。

## CSV について

本変更で db/data/*.csv の中身は変わらない (ProgressBar は I/O だけ動かしていて生成データには関与しない) ため再生成・差分は含めていない。

## Test plan

- [ ] 開発環境で \`docker-compose run --rm app bin/rails data:generate\` が 1 分以内に完了する
- [ ] 各都道府県の完了サマリが puts で出力される (Tracks 12: ... curves など)

🤖 Generated with [Claude Code](https://claude.com/claude-code)