### PR TITLE
Drop ruby-progressbar gem and remove last ProgressBar usage

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -88,7 +88,6 @@ gem "google-analytics-rails"
 gem "newrelic_rpm"
 gem "sitemap_generator"
 gem "cache_clear_rails"
-gem "ruby-progressbar"
 gem "simplify_rb"
 gem "simplecov", require: false, group: :test
 gem "rails-erd", group: :development

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -475,7 +475,6 @@ DEPENDENCIES
   rails (~> 8.1.3)
   rails-erd
   rubocop-rails-omakase
-  ruby-progressbar
   sassc-rails
   selenium-webdriver
   simplecov

--- a/lib/tasks/keyword.rake
+++ b/lib/tasks/keyword.rake
@@ -46,8 +46,8 @@ namespace :keyword do
     # find_each はデフォルトで id ASC でバッチ取得するため、出力 CSV は自動的に id 順に揃う。
     # CSV.open のブロック内で 1 行ずつストリーミング書き出しすることで、5 万件分をメモリに
     # ためずに済む（前バージョンは rows 配列に全件蓄積していた）。
+    $stdout.sync = true
     total = BusStop.count
-    progress = ProgressBar.create(title: "Generate", total: total, format: "%t: %J%% |%B|")
     CSV.open(csv_path, "w", headers: %w[bus_stop_id keyword], write_headers: true) do |csv|
       BusStop.find_each do |bus_stop|
         # kakasi のオプション解説（末尾の文字が「変換先」、それより前の大文字が「変換元」）:
@@ -66,7 +66,6 @@ namespace :keyword do
           KakasiParser.kakasi("-JK -aK -HK -kK -EK -p", bus_stop.name).join(" ")
         ].join(" ")
         csv << [ bus_stop.id, keyword ]
-        progress.increment
       end
     end
     puts "Wrote #{csv_path} (#{total} rows)"


### PR DESCRIPTION
## Summary

- `lib/tasks/keyword.rake` に唯一残っていた `ProgressBar` 使用を削除
- `Gemfile` から `gem \"ruby-progressbar\"` を削除 (直接依存を解除)
- gem 自体は `rubocop-rails-omakase` の transitive 依存として Gemfile.lock に残るため、rubocop の進捗表示には影響しない

## なぜ

PR #44 / #46 で `data.rake` と `bus_stop_number.rake` からは `ProgressBar` を撤去済みだが、`keyword.rake` で 1 箇所だけ残っていた。`bus_stop_number:diagnose` の改修 (PR #48) を機にコードベースから完全撤去する。

進捗表示が必要になったら ProgressBar の代わりに簡素な puts / print で十分という方針 (PR #46 で確認済み)。

## Test plan

- [x] `grep -rn ProgressBar lib app test` で参照ゼロを確認
- [x] `bundle install` 成功 (44 → 43 dependencies)
- [x] 全テスト pass (71 runs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)