### PR TITLE
Re-add click to mouseleave handler for touch device hover-reset

### DIFF
--- a/app/assets/javascripts/common.js
+++ b/app/assets/javascripts/common.js
@@ -112,18 +112,24 @@
     $(document).on("click", SELECTOR_SEARCH_MAP_CENTER, handleSearchMapCenterClick);
 
     // 路線リンク ↔ polyline の連動
+    // ※ reset 側に "click" も含めるのは iOS / Android のタッチ端末対応。
+    //    touch では tap で `mouseenter` (合成) → `click` の順に発火するが、
+    //    `mouseleave` は安定的に発火しない端末がある。click をフックしておくと
+    //    タップで一瞬 highlight された後に確実にリセットでき、ハイライトが
+    //    居残るのを防げる。クリックではページ遷移も走るが、ハンドラが先に
+    //    実行されるので「reset → 遷移」の順で副作用なし。
     $(document).on("mouseenter", SELECTOR_BUS_ROUTE_LINK, function() {
       setBusRouteHighlight($(this), true);
     });
-    $(document).on("mouseleave", SELECTOR_BUS_ROUTE_LINK, function() {
+    $(document).on("mouseleave click", SELECTOR_BUS_ROUTE_LINK, function() {
       setBusRouteHighlight($(this), false);
     });
 
-    // 停留所リンク ↔ marker の連動
+    // 停留所リンク ↔ marker の連動 (同様に click も含める)
     $(document).on("mouseenter", SELECTOR_BUS_STOP_LINK, function() {
       setBusStopAnimation($(this), google.maps.Animation.BOUNCE);
     });
-    $(document).on("mouseleave", SELECTOR_BUS_STOP_LINK, function() {
+    $(document).on("mouseleave click", SELECTOR_BUS_STOP_LINK, function() {
       setBusStopAnimation($(this), null);
     });
   });


### PR DESCRIPTION
## Summary

`common.js` の reset 側イベント登録に `click` を再追加して、iOS / Android のタッチ端末でハイライトが居残る問題を解消する。

## なぜ

タッチ端末では tap 時に下記順で合成イベントが発火する:

```
touchstart → touchend → mouseover/enter (合成) → click
```

`mouseleave` は端末・ブラウザによって安定的に発火せず、tap で mouseenter (= ハイライト) だけ走って以降のリセットが起きないケースがある。click をフックしておけば、tap のたびに確実にハイライトが解除される。

## 経緯

これは元の `common.coffee` で意図的に書かれていた挙動 (`\"mouseleave click\"`) で、9d62496 の CoffeeScript → JS 化 + f89de6c のリファクタの過程で `click` が落ちていた。今回コメントに意図も明記して再発防止する。

## クリックの副作用について

`a[data-bus-route-link]` / `a[data-bus-stop-link]` の click は通常ページ遷移を引き起こすが、ハンドラが先に実行されるので「reset → 遷移」の順で副作用なし (むしろ次ページ遷移時にハイライトが消えた状態になる)。

## Test plan

- [x] `bin/rubocop` (JS は対象外だが既存ルール変更なし)
- [ ] iPad / iPhone の Safari で bus_route 詳細ページのバス停リストを tap → 別ページに遷移する際にバウンスが居残らないことを目視確認 (manual)

🤖 Generated with [Claude Code](https://claude.com/claude-code)