### PR TITLE
Speed up bus stop search with pg_trgm GIN indexes

### DIFF
--- a/app/controllers/bus_stops_controller.rb
+++ b/app/controllers/bus_stops_controller.rb
@@ -1,7 +1,15 @@
 class BusStopsController < ApplicationController
   def index
     if params[:q] then
-      @bus_stops = BusStop.preload(:bus_routes).where("lower(keyword) like lower(?)", "%#{params[:q]}%").order("name, latitude DESC").limit(100)
+      # `keyword` と `name` の両方に GIN trigram インデックス (pg_trgm) を張っている。
+      # `lower()` で wrap すると planner が index を使えなくなるため ILIKE で書く。
+      # OR にしているのは keyword:load 未実行 / kakasi 失敗で keyword が NULL の停留所も
+      # name 側で hit させて Google Places フォールバックに流れないようにする保険。
+      # 3 文字以上の検索なら BitmapOr で両 index を結合して ~0.3ms。
+      pattern = "%#{params[:q]}%"
+      @bus_stops = BusStop.preload(:bus_routes)
+                          .where("keyword ILIKE :p OR name ILIKE :p", p: pattern)
+                          .order("name, latitude DESC").limit(100)
       if @bus_stops.empty?
         client = GooglePlaces::Client.new(ENV["GOOGLE_API_KEY"])
         spots = Rails.cache.fetch(params[:q]) do

--- a/db/migrate/20260508065747_add_trigram_index_to_bus_stops_keyword.rb
+++ b/db/migrate/20260508065747_add_trigram_index_to_bus_stops_keyword.rb
@@ -1,0 +1,9 @@
+class AddTrigramIndexToBusStopsKeyword < ActiveRecord::Migration[8.1]
+  # PostgreSQL の B-tree インデックスは LIKE '%xxx%' (substring) を高速化できない。
+  # pg_trgm 拡張 + GIN trigram インデックスで部分一致検索を高速化する。
+  # 全国対応で bus_stops が 254,842 件まで増え、現状の Seq Scan で ~900ms かかっていた。
+  def change
+    enable_extension :pg_trgm
+    add_index :bus_stops, :keyword, using: :gin, opclass: :gin_trgm_ops
+  end
+end

--- a/db/migrate/20260508070809_add_trigram_index_to_bus_stops_name.rb
+++ b/db/migrate/20260508070809_add_trigram_index_to_bus_stops_name.rb
@@ -1,0 +1,8 @@
+class AddTrigramIndexToBusStopsName < ActiveRecord::Migration[8.1]
+  # `keyword` が空 (= keyword:load 未実行 / kakasi 失敗) の停留所を救済するため、検索クエリで
+  # `name ILIKE` を OR 条件に加える。`name` 側にも GIN trigram index を張り、3 文字以上の
+  # 検索なら BitmapOr で両 index を結合して同等速度 (~0.3ms) を維持する。
+  def change
+    add_index :bus_stops, :name, using: :gin, opclass: :gin_trgm_ops
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,10 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_08_061740) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_08_070809) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
+  enable_extension "pg_trgm"
 
   create_table "bus_route_bus_stops", id: :serial, force: :cascade do |t|
     t.integer "bus_route_id"
@@ -58,6 +59,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_08_061740) do
     t.string "name"
     t.string "prefecture"
     t.datetime "updated_at", precision: nil, null: false
+    t.index ["keyword"], name: "index_bus_stops_on_keyword", opclass: :gin_trgm_ops, using: :gin
+    t.index ["name"], name: "index_bus_stops_on_name", opclass: :gin_trgm_ops, using: :gin
   end
 
   add_foreign_key "bus_route_bus_stops", "bus_routes"


### PR DESCRIPTION
## Summary

全国対応で bus_stops が 254,842 件まで増え、検索が **~860ms** まで悪化していた。`pg_trgm` 拡張 + GIN trigram index で **~0.3ms** (約 2,800 倍高速化) に改善する。

## 原因

1. `bus_stops` テーブルに index が無い (id 以外)
2. クエリ `lower(keyword) LIKE lower(?)` の `lower()` wrap が trigram index 利用を阻害

EXPLAIN ANALYZE: Parallel Seq Scan で全件 254,842 行スキャン。

## 変更内容

- `enable_extension :pg_trgm`
- `add_index :bus_stops, :keyword, using: :gin, opclass: :gin_trgm_ops`
- `add_index :bus_stops, :name, using: :gin, opclass: :gin_trgm_ops`
- controller のクエリを `keyword ILIKE :p OR name ILIKE :p` に変更

## name 側にも index + OR 条件にした理由

`keyword` は `name + romaji + hiragana + katakana` を含むので通常は keyword 単独で十分。ただし `keyword:load` 未実行や kakasi 失敗で keyword が NULL の停留所がある場合、現状の controller は Google Places API にフォールバックしてしまい、本来 name で hit するはずの停留所が結果から消える。

OR で `name` を含めることで:
- 通常運用: BitmapOr で両 index 利用、性能変わらず
- データ部分破損時: name 側で hit して救済される

## 性能結果 (「渋谷駅」3 文字検索)

| 状態 | 計画 | 実行時間 |
|---|---|---:|
| 旧 (lower wrap) | Parallel Seq Scan | 860ms |
| 新 (ILIKE OR) | BitmapOr (両 index) | 0.3ms |

実測 warm cache: 0.5ms。2 文字以下の検索は trigram 制約で Seq Scan になるが warm cache で実用可能。

## CSV import 後の挙動

`data:load` (TRUNCATE + COPY) では index は削除されず、COPY 中に自動更新される。CSV 再投入時の手動 reindex 不要。確認済み。

## Test plan

- [ ] `bin/rails db:migrate` で migration が通ること (index 構築 ~25 秒)
- [ ] `/bus_stops?q=渋谷駅` で結果が即座に表示されること
- [ ] `bin/rails bus_stop_number:load` 等の関連タスクが影響を受けないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)