### PR TITLE
Upgrade PostgreSQL from 15 to 17 to match production

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
 
     services:
       postgres:
-          image: postgres:15
+          image: postgres:17
           ports:
             - 5432:5432
           env:
@@ -111,7 +111,7 @@ jobs:
 
     services:
       postgres:
-          image: postgres:15
+          image: postgres:17
           ports:
             - 5432:5432
           env:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
       - "4444:4444"
 
   db:
-    image: postgres:15
+    image: postgres:17
     platform: linux/arm64
     ports:
       - "5432:5432"


### PR DESCRIPTION
## Summary

本番 Heroku の PostgreSQL が 17 だと判明したので、開発環境 / CI を合わせる。

## 変更

- `docker-compose.yml`: `postgres:15` → `postgres:17`
- `.github/workflows/ci.yml` (test / system-test job): `postgres:15` → `postgres:17`

## 手元での再構築手順

PG 15 の data volume は PG 17 image でそのまま読めないため作り直しが必要:

```
docker-compose down
docker volume rm chi-busjp_db_data
docker-compose up -d   # entry が db:create / db:migrate を流す
bin/rails db:seed      # 全 CSV をロード
```

## Test plan

- [ ] PR の CI (postgres 17 service container) が通ること
- [ ] マージ後ローカル: `docker-compose down && docker volume rm chi-busjp_db_data && docker-compose up -d && bin/rails db:seed` で復元できること

🤖 Generated with [Claude Code](https://claude.com/claude-code)