### PR TITLE
Replace kakasi C-extension gem with FFI wrapper

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 - Ruby のバージョンは `.ruby-version` で固定。
 - 全環境（development / test / production）で **PostgreSQL**。`docker-compose up` で app / db / selenium のコンテナが揃う。`Dockerfile.dev` が development 用、`Dockerfile`（rails new デフォルト）が production 用。
-- `kakasi_parser` は development グループに常駐。`keyword:generate`（後述）が要求する。OS 側の `kakasi` コマンドも要るが `Dockerfile.dev` に同梱済み。ホスト直で `bundle install` すると build に失敗するので Docker 経由で動かす前提。
+- `keyword:generate` (後述) は `libkakasi.so.2` を要求する。`Dockerfile.dev` に kakasi コマンドを入れているのでランタイム共有ライブラリも一緒に入る。`lib/kakasi.rb` から FFI で attach する。
 
 ## よく使うコマンド
 
@@ -87,7 +87,7 @@ CI は `.github/workflows/ci.yml`（GitHub Actions）。lint / scan_ruby / scan_
 
 ### 検索キーワード
 
-`bus_stops.keyword` は「停留所名 + kakasi で変換したローマ字 + ひらがな + カタカナ」を空白区切りで連結したテキストで、漢字・かな・ローマ字いずれの入力でも `LIKE` でヒットする。生成は `lib/tasks/keyword.rake` の `keyword:generate`（要 `kakasi_parser`）。kakasi の内部エンコーディング (CP932) で表現できない希少漢字を含む停留所名 (47 都道府県分で 22 件) は変換失敗するため、`begin/rescue` で `bus_stop.name` 単体にフォールバックする。
+`bus_stops.keyword` は「停留所名 + kakasi で変換したローマ字 + ひらがな + カタカナ」を空白区切りで連結したテキストで、漢字・かな・ローマ字いずれの入力でも `LIKE` でヒットする。生成は `lib/tasks/keyword.rake` の `keyword:generate`。kakasi の内部エンコーディング (CP932) で表現できない希少漢字を含む停留所名 (47 都道府県分で 22 件) は変換失敗するため、`begin/rescue` で `bus_stop.name` 単体にフォールバックする。kakasi の呼び出しは `lib/kakasi.rb` (FFI で `libkakasi.so.2` を attach、元 `kakasi` gem の代替) と `lib/kakasi_parser.rb` (元 `kakasi_parser` gem のポート、`{a|b}` 形式の曖昧読み候補を直積で展開) に分離。
 
 ### 派生データの計算ロジック (`lib/`)
 
@@ -116,7 +116,7 @@ XML + JSON のソースから `db/data/*.csv.gz` を生成し、gzip 圧縮し�
 - `data:load` — `db/data/*.csv.gz` を `COPY FROM STDIN` で DB に流し込む。Heroku でも実行可能で約 1 分。`db/seeds.rb` のガード経由で `bin/rails db:seed` から呼ばれるルートと、直接 `bin/rails data:load` で呼ぶルートの両方がある。
 - `bus_stop_number:generate` — `db/data/bus_stop_numbers.csv.gz` を生成。重い処理だが結果を git に commit するので CI / 通常セットアップでは load のみ呼べばよい。
 - `geocode:generate` — `db/isj/` の ISJ CSV を読み、各 bus_stop の最近接 entry から `db/data/geocoding.csv.gz` (city, formatted_address) を生成。所要 10 秒程度。ISJ raw データ (db/isj/) はダウンロード必要、生成 CSV だけ commit する。
-- `keyword:generate` — kakasi で `db/data/keywords.csv.gz` を生成 (kakasi gem 要)。
+- `keyword:generate` — kakasi で `db/data/keywords.csv.gz` を生成 (`libkakasi.so.2` 要、Dockerfile.dev の kakasi パッケージに同梱)。
 - 各 `*:load` — 対応する CSV を bulk UPDATE で DB に投入。
 
 ### テスト

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -6,7 +6,6 @@ RUN apt-get update \
         nodejs \
         graphviz \
         kakasi \
-        libkakasi2-dev \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /usr/src/app

--- a/Gemfile
+++ b/Gemfile
@@ -91,9 +91,7 @@ gem "cache_clear_rails"
 gem "simplify_rb"
 gem "simplecov", require: false, group: :test
 gem "rails-erd", group: :development
-# rails keyword:generate タスクで使用
-gem "kakasi_parser", group: :development
-# kakasi gem の実行時依存（Ruby 4.0 で default gem から外れるため明示）
-gem "fiddle", group: :development
+# lib/kakasi.rb で libkakasi.so.2 を attach するのに使用
+gem "ffi"
 # data:profile タスクで使用 (sampling profiler、低オーバーヘッド)
 gem "stackprof", require: false, group: :development

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -137,7 +137,6 @@ GEM
     ffi (1.17.4-aarch64-linux-gnu)
     ffi (1.17.4-arm64-darwin)
     ffi (1.17.4-x86_64-linux-gnu)
-    fiddle (1.1.8)
     fugit (1.12.1)
       et-orbi (~> 1.4)
       raabro (~> 1.4)
@@ -177,9 +176,6 @@ GEM
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
     json (2.19.5)
-    kakasi (1.0.2)
-    kakasi_parser (0.1.0)
-      kakasi (>= 1.0)
     kamal (2.11.0)
       activesupport (>= 7.0)
       base64 (~> 0.2)
@@ -456,7 +452,7 @@ DEPENDENCIES
   coffee-rails
   debug
   dotenv-rails
-  fiddle
+  ffi
   geocoder
   gmaps4rails
   google-analytics-rails
@@ -465,7 +461,6 @@ DEPENDENCIES
   importmap-rails
   jbuilder
   jquery-rails
-  kakasi_parser
   kamal
   minitest-rails
   newrelic_rpm

--- a/lib/kakasi.rb
+++ b/lib/kakasi.rb
@@ -1,0 +1,67 @@
+require "ffi"
+
+# 元 kakasi gem (https://github.com/m-tom-h/kakasi-ruby) のポート。
+# パブリック API は元 gem と同じく `Kakasi.kakasi(options, text) -> String`。
+#
+# libkakasi.so.2 を FFI で動的にロードして in-process で叩く。元 gem は
+# fiddle / ffi の 2 backend を持っていたが、Ruby LSP との相性で C 拡張系を
+# 避けたいため ffi gem (libffi の Ruby バインディング、ビルド不要) のみ使う。
+#
+# libkakasi はグローバル単一状態なので options が変わるたびに
+# kakasi_close_kanwadict + kakasi_getopt_argv で辞書を載せ替える (元 gem 同様)。
+# Pointer#read_string は C 文字列セマンティクスで NUL の手前まで読むため、
+# kakasi が出力に NUL+junk を挿むケース (CP932 で表現できない記号など) も
+# 自動的に切り落とされる。
+module Kakasi
+  module Lib
+    extend FFI::Library
+
+    # libkakasi.so.2 は keyword:generate でしか使わないが、Zeitwerk が production
+    # 起動時に lib/ を eager load するため、Heroku などライブラリが無い環境でも
+    # ロード時に落ちないよう begin/rescue で防御する。Kakasi.kakasi 呼び出し時に
+    # 改めて raise させる。
+    AVAILABLE = begin
+      ffi_lib "libkakasi.so.2"
+      attach_function :kakasi_getopt_argv, [ :int, :pointer ], :int
+      attach_function :kakasi_do, [ :string ], :pointer
+      attach_function :kakasi_close_kanwadict, [], :int
+      attach_function :kakasi_free, [ :pointer ], :int
+      true
+    rescue LoadError
+      false
+    end
+  end
+
+  INTERNAL_ENCODING = Encoding::CP932
+
+  @mutex = Mutex.new
+  @options = nil
+
+  module_function
+
+  def kakasi(options, string)
+    raise LoadError, "libkakasi.so.2 not available (install kakasi package)" unless Lib::AVAILABLE
+
+    @mutex.synchronize do
+      if options != @options
+        Lib.kakasi_close_kanwadict if @options
+        args = [ "kakasi", *options.split ]
+        argv = FFI::MemoryPointer.new(:pointer, args.size).write_array_of_pointer(
+          args.map { |arg| FFI::MemoryPointer.from_string(arg) }
+        )
+        Lib.kakasi_getopt_argv(args.size, argv).zero? or raise "failed to initialize kakasi"
+        @options = options.dup
+      end
+
+      encoding = string.encoding
+      result = "".force_encoding(INTERNAL_ENCODING)
+      string.encode(INTERNAL_ENCODING).split(/(\0+)/).each do |str, nul|
+        buf = Lib.kakasi_do(str)
+        result << buf.read_string.force_encoding(INTERNAL_ENCODING)
+        Lib.kakasi_free(buf)
+        result << nul if nul
+      end
+      result.encode(encoding)
+    end
+  end
+end

--- a/lib/kakasi_parser.rb
+++ b/lib/kakasi_parser.rb
@@ -1,0 +1,16 @@
+# 元 kakasi_parser gem (https://github.com/yamamuteki/kakasi_parser) のポート。
+# Zeitwerk autoload で Kakasi (lib/kakasi.rb) も自動的に解決される。
+module KakasiParser
+  module_function
+
+  def parse(kakasi_result)
+    kakasi_result.scan(/[^{}]+/)
+                 .map { |match| match.split("|") }
+                 .reduce { |a, b| a.product(b) }
+                 .map { |reading| reading.is_a?(Array) ? reading.join : reading }
+  end
+
+  def kakasi(options, original)
+    parse(Kakasi.kakasi(options, original))
+  end
+end


### PR DESCRIPTION
## Summary

- Ruby LSP との相性問題で `kakasi_parser` / `kakasi` gem 依存を撤廃し、同等機能を `lib/` に内製化
- `libkakasi.so.2` を `ffi` gem で in-process attach (元 `kakasi` gem の ffi backend を写経、API も同じ)
- `lib/kakasi.rb` の `ffi_lib` 呼び出しを `begin/rescue LoadError` で防御 — Heroku などライブラリが無い環境でも Zeitwerk eager load 時にクラッシュせず、`Kakasi.kakasi` 呼び出し時に明示的な LoadError で失敗

`lib/tasks/keyword.rake` は無変更。`Pointer#read_string` が C 文字列セマンティクスで NUL の手前まで読むため、kakasi が出力に NUL+junk を挿む特殊文字 (① 等) も自動的に切り落とされる。

## Test plan

- [x] `bin/rails keyword:generate` を実行し、既存 `db/data/keywords.csv.gz` と sha256 完全一致を確認
- [x] CP932 不可漢字 (𠮷野家など) で `Encoding::UndefinedConversionError` 経路に乗り、22 件のフォールバックが維持されることを確認
- [x] libkakasi.so.2 を Docker 内で全削除した状態で `Rails.application.eager_load!` がクラッシュせず、`Kakasi.kakasi` 呼び出しでのみ LoadError が出ることを確認 (Heroku boot 相当)

🤖 Generated with [Claude Code](https://claude.com/claude-code)