### PR TITLE
Move Google Maps key and GA tracker ID to ENV

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,7 @@ jobs:
           RAILS_DATABASE_USER: postgres
           RAILS_DATABASE_PASSWORD: postgres
           GOOGLE_API_KEY: dummy
+          GOOGLE_MAPS_API_KEY: dummy
         run: bin/rails db:test:prepare test
 
   system-test:
@@ -144,6 +145,7 @@ jobs:
           RAILS_DATABASE_USER: postgres
           RAILS_DATABASE_PASSWORD: postgres
           GOOGLE_API_KEY: dummy
+          GOOGLE_MAPS_API_KEY: dummy
           SELENIUM_REMOTE_URL: http://localhost:4444/wd/hub
         run: bin/rails db:test:prepare test:system
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -163,8 +163,8 @@ XML + JSON のソースから `db/data/*.csv.gz` を生成し、gzip 圧縮し�
 ### 外部依存と認証情報
 
 - Google Places API キー — `ENV["GOOGLE_API_KEY"]`。検索ヒット 0 件時のフォールバックでのみ使う。Geocoding は ISJ オフラインデータ (`lib/isj_reverse_geocoder.rb`) に移行したため Google Geocoding API は使っていない。
-- **Google Maps JavaScript API キーは `app/views/layouts/application.html.erb` にハードコードされている**（修正候補）。
-- Google Analytics トラッカー ID は `config/environments/production.rb` にハードコード。
+- Google Maps JavaScript API キー — `ENV["GOOGLE_MAPS_API_KEY"]` (`app/views/layouts/application.html.erb`)。HTML に埋め込まれるためリファラ制限前提。Places 用と分けてあるのは公開面 (Maps) と非公開面 (Places) で Google Cloud 側の制限ポリシーが違うため。
+- Google Analytics トラッカー ID — `ENV["GA_TRACKER_ID"]` (`config/environments/production.rb`)。未設定なら `valid_tracker?` ガードで `analytics_init` がスキップされるので production 以外では何もしない。
 - New Relic（`newrelic_rpm`）は production で有効。
 - `dotenv-rails` で `.env` を読み込み（`.env` は gitignore 済み）。
 - CI test job では `GOOGLE_API_KEY: dummy` を渡してモック前提のテストを通している。

--- a/README.md
+++ b/README.md
@@ -7,7 +7,9 @@
 
 ## 環境変数
 
-- `GOOGLE_API_KEY` — Google Places / Geocoding API のキー
+- `GOOGLE_API_KEY` — Google Places API のキー（検索 0 件時のフォールバック用、サーバーサイド呼び出し）
+- `GOOGLE_MAPS_API_KEY` — Google Maps JavaScript API のキー（地図表示用、HTML に埋め込まれるためリファラ制限を推奨）
+- `GA_TRACKER_ID` — Google Analytics トラッカー ID（production のみ。未設定なら計測しない）
 - `RAILS_DATABASE_HOST`
 - `RAILS_DATABASE_PORT`
 - `RAILS_DATABASE_USER`
@@ -58,7 +60,7 @@ DB セットアップとキャッシュクリアは buildpack 方式で行いま
 1. Heroku アカウントを作成し、Heroku web console でアプリを作成
 2. `heroku login`
 3. Heroku Postgres アドオンを追加
-4. config vars に `GOOGLE_API_KEY`、`SECRET_KEY_BASE`、`RAILS_LOG_TO_STDOUT=enabled`、`RAILS_SERVE_STATIC_FILES=enabled` などを設定
+4. config vars に `GOOGLE_API_KEY`、`GOOGLE_MAPS_API_KEY`、`GA_TRACKER_ID`、`SECRET_KEY_BASE`、`RAILS_LOG_TO_STDOUT=enabled`、`RAILS_SERVE_STATIC_FILES=enabled` などを設定
 5. heroku CLI を対象アプリに関連付ける（以降の `heroku` コマンドで `-a <app名>` を毎回指定しなくて済む。デプロイ自体は GitHub 連携経由なのでこの remote 経由で push する必要はない）：
 
    ```

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -18,7 +18,7 @@
     <%= javascript_include_tag 'application', 'data-turbolinks-track' => true %>
     <%= csrf_meta_tags %>
     <%= analytics_init if GoogleAnalytics.valid_tracker? %>
-    <script src="//maps.google.com/maps/api/js?key=AIzaSyDgBqFhJHIOXtF32jGmkFeNzbt6EMYGDKE&libraries=geometry"></script>
+    <script src="//maps.google.com/maps/api/js?key=<%= ENV["GOOGLE_MAPS_API_KEY"] %>&libraries=geometry"></script>
     <script src="//cdn.rawgit.com/mahnunchik/markerclustererplus/master/dist/markerclusterer.min.js"></script>
     <%= javascript_importmap_tags "main" %>
   </head>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -78,6 +78,8 @@ Rails.application.configure do
   # Only use :id for inspections in production.
   config.active_record.attributes_for_inspect = [ :id ]
 
+  GA.tracker = ENV["GA_TRACKER_ID"]
+
   # Enable DNS rebinding protection and other `Host` header attacks.
   # config.hosts = [
   #   "example.com",     # Allow requests from example.com


### PR DESCRIPTION
## Summary
- `app/views/layouts/application.html.erb` にハードコードされていた Google Maps JavaScript API キーを `ENV["GOOGLE_MAPS_API_KEY"]` に移行 (Places 用 `GOOGLE_API_KEY` とは別キー運用、リファラ制限を前提)
- Rails 8.1 化で `production.rb` から脱落していた GA トラッカー ID 設定を `ENV["GA_TRACKER_ID"]` 経由で復活 (production のみ、未設定なら `valid_tracker?` ガードでスキップ)
- CI / README / CLAUDE.md の env 一覧と Heroku setup 手順を実態に合わせて更新

## Test plan
- [ ] Heroku の config var に `GOOGLE_MAPS_API_KEY`, `GA_TRACKER_ID` が設定済みであることを確認 (本 PR マージ前)
- [ ] マージ後、production の任意の地図ページ (`/bus_routes/:id`) で Google Maps が表示されること
- [ ] マージ後、production の HTML に `analytics_init` 由来の GA タグが出力されること (ただし `UA-` 形式のままだと GA 側ではデータ収集されない点に注意。GA4 移行は別タスク)