### PR TITLE
Rename Google ENV keys to match Cloud product names

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,7 @@ jobs:
           RAILS_DATABASE_PORT: 5432
           RAILS_DATABASE_USER: postgres
           RAILS_DATABASE_PASSWORD: postgres
-          GOOGLE_API_KEY: dummy
+          GOOGLE_PLACES_API_KEY: dummy
           GOOGLE_MAPS_API_KEY: dummy
         run: bin/rails db:test:prepare test
 
@@ -144,7 +144,7 @@ jobs:
           RAILS_DATABASE_PORT: 5432
           RAILS_DATABASE_USER: postgres
           RAILS_DATABASE_PASSWORD: postgres
-          GOOGLE_API_KEY: dummy
+          GOOGLE_PLACES_API_KEY: dummy
           GOOGLE_MAPS_API_KEY: dummy
           SELENIUM_REMOTE_URL: http://localhost:4444/wd/hub
         run: bin/rails db:test:prepare test:system

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,7 @@ jobs:
           RAILS_DATABASE_USER: postgres
           RAILS_DATABASE_PASSWORD: postgres
           GOOGLE_PLACES_API_KEY: dummy
-          GOOGLE_MAPS_API_KEY: dummy
+          GOOGLE_MAPS_JS_API_KEY: dummy
         run: bin/rails db:test:prepare test
 
   system-test:
@@ -145,7 +145,7 @@ jobs:
           RAILS_DATABASE_USER: postgres
           RAILS_DATABASE_PASSWORD: postgres
           GOOGLE_PLACES_API_KEY: dummy
-          GOOGLE_MAPS_API_KEY: dummy
+          GOOGLE_MAPS_JS_API_KEY: dummy
           SELENIUM_REMOTE_URL: http://localhost:4444/wd/hub
         run: bin/rails db:test:prepare test:system
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -162,12 +162,12 @@ XML + JSON のソースから `db/data/*.csv.gz` を生成し、gzip 圧縮し�
 
 ### 外部依存と認証情報
 
-- Google Places API キー — `ENV["GOOGLE_API_KEY"]`。検索ヒット 0 件時のフォールバックでのみ使う。Geocoding は ISJ オフラインデータ (`lib/isj_reverse_geocoder.rb`) に移行したため Google Geocoding API は使っていない。
+- Google Places API キー — `ENV["GOOGLE_PLACES_API_KEY"]`。検索ヒット 0 件時のフォールバックでのみ使う。Geocoding は ISJ オフラインデータ (`lib/isj_reverse_geocoder.rb`) に移行したため Google Geocoding API は使っておらず、`config/initializers/geocoder.rb` も api_key 未設定。
 - Google Maps JavaScript API キー — `ENV["GOOGLE_MAPS_API_KEY"]` (`app/views/layouts/application.html.erb`)。HTML に埋め込まれるためリファラ制限前提。Places 用と分けてあるのは公開面 (Maps) と非公開面 (Places) で Google Cloud 側の制限ポリシーが違うため。
 - Google Analytics トラッカー ID — `ENV["GA_TRACKER_ID"]` (`config/environments/production.rb`)。未設定なら `valid_tracker?` ガードで `analytics_init` がスキップされるので production 以外では何もしない。
 - New Relic（`newrelic_rpm`）は production で有効。
 - `dotenv-rails` で `.env` を読み込み（`.env` は gitignore 済み）。
-- CI test job では `GOOGLE_API_KEY: dummy` を渡してモック前提のテストを通している。
+- CI test job では `GOOGLE_PLACES_API_KEY: dummy` を渡してモック前提のテストを通している。
 
 ### 本番環境の追加設定
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -163,7 +163,7 @@ XML + JSON のソースから `db/data/*.csv.gz` を生成し、gzip 圧縮し�
 ### 外部依存と認証情報
 
 - Google Places API キー — `ENV["GOOGLE_PLACES_API_KEY"]`。検索ヒット 0 件時のフォールバックでのみ使う。Geocoding は ISJ オフラインデータ (`lib/isj_reverse_geocoder.rb`) に移行したため Google Geocoding API は使っておらず、`config/initializers/geocoder.rb` も api_key 未設定。
-- Google Maps JavaScript API キー — `ENV["GOOGLE_MAPS_API_KEY"]` (`app/views/layouts/application.html.erb`)。HTML に埋め込まれるためリファラ制限前提。Places 用と分けてあるのは公開面 (Maps) と非公開面 (Places) で Google Cloud 側の制限ポリシーが違うため。
+- Google Maps JavaScript API キー — `ENV["GOOGLE_MAPS_JS_API_KEY"]` (`app/views/layouts/application.html.erb`)。HTML に埋め込まれるためリファラ制限前提。Places 用と分けてあるのは公開面 (Maps) と非公開面 (Places) で Google Cloud 側の制限ポリシーが違うため。ENV 名を `MAPS_JS` まで詳細にしているのは Google Maps Platform にサーバーサイド製品 (Geocoding / Directions / Distance Matrix / Maps Static など) も多数あり、将来追加した時に用途が一目で分かるようにするため。
 - Google Analytics トラッカー ID — `ENV["GA_TRACKER_ID"]` (`config/environments/production.rb`)。未設定なら `valid_tracker?` ガードで `analytics_init` がスキップされるので production 以外では何もしない。
 - New Relic（`newrelic_rpm`）は production で有効。
 - `dotenv-rails` で `.env` を読み込み（`.env` は gitignore 済み）。

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 ## 環境変数
 
 - `GOOGLE_PLACES_API_KEY` — Google Places API のキー（検索 0 件時のフォールバック用、サーバーサイド呼び出し）
-- `GOOGLE_MAPS_API_KEY` — Google Maps JavaScript API のキー（地図表示用、HTML に埋め込まれるためリファラ制限を推奨）
+- `GOOGLE_MAPS_JS_API_KEY` — Google Maps JavaScript API のキー（地図表示用、HTML に埋め込まれるためリファラ制限を推奨）
 - `GA_TRACKER_ID` — Google Analytics トラッカー ID（production のみ。未設定なら計測しない）
 - `RAILS_DATABASE_HOST`
 - `RAILS_DATABASE_PORT`
@@ -60,7 +60,7 @@ DB セットアップとキャッシュクリアは buildpack 方式で行いま
 1. Heroku アカウントを作成し、Heroku web console でアプリを作成
 2. `heroku login`
 3. Heroku Postgres アドオンを追加
-4. config vars に `GOOGLE_PLACES_API_KEY`、`GOOGLE_MAPS_API_KEY`、`GA_TRACKER_ID`、`SECRET_KEY_BASE`、`RAILS_LOG_TO_STDOUT=enabled`、`RAILS_SERVE_STATIC_FILES=enabled` などを設定
+4. config vars に `GOOGLE_PLACES_API_KEY`、`GOOGLE_MAPS_JS_API_KEY`、`GA_TRACKER_ID`、`SECRET_KEY_BASE`、`RAILS_LOG_TO_STDOUT=enabled`、`RAILS_SERVE_STATIC_FILES=enabled` などを設定
 5. heroku CLI を対象アプリに関連付ける（以降の `heroku` コマンドで `-a <app名>` を毎回指定しなくて済む。デプロイ自体は GitHub 連携経由なのでこの remote 経由で push する必要はない）：
 
    ```

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 ## 環境変数
 
-- `GOOGLE_API_KEY` — Google Places API のキー（検索 0 件時のフォールバック用、サーバーサイド呼び出し）
+- `GOOGLE_PLACES_API_KEY` — Google Places API のキー（検索 0 件時のフォールバック用、サーバーサイド呼び出し）
 - `GOOGLE_MAPS_API_KEY` — Google Maps JavaScript API のキー（地図表示用、HTML に埋め込まれるためリファラ制限を推奨）
 - `GA_TRACKER_ID` — Google Analytics トラッカー ID（production のみ。未設定なら計測しない）
 - `RAILS_DATABASE_HOST`
@@ -60,7 +60,7 @@ DB セットアップとキャッシュクリアは buildpack 方式で行いま
 1. Heroku アカウントを作成し、Heroku web console でアプリを作成
 2. `heroku login`
 3. Heroku Postgres アドオンを追加
-4. config vars に `GOOGLE_API_KEY`、`GOOGLE_MAPS_API_KEY`、`GA_TRACKER_ID`、`SECRET_KEY_BASE`、`RAILS_LOG_TO_STDOUT=enabled`、`RAILS_SERVE_STATIC_FILES=enabled` などを設定
+4. config vars に `GOOGLE_PLACES_API_KEY`、`GOOGLE_MAPS_API_KEY`、`GA_TRACKER_ID`、`SECRET_KEY_BASE`、`RAILS_LOG_TO_STDOUT=enabled`、`RAILS_SERVE_STATIC_FILES=enabled` などを設定
 5. heroku CLI を対象アプリに関連付ける（以降の `heroku` コマンドで `-a <app名>` を毎回指定しなくて済む。デプロイ自体は GitHub 連携経由なのでこの remote 経由で push する必要はない）：
 
    ```

--- a/app/controllers/bus_stops_controller.rb
+++ b/app/controllers/bus_stops_controller.rb
@@ -11,7 +11,7 @@ class BusStopsController < ApplicationController
                           .where("keyword ILIKE :p OR name ILIKE :p", p: pattern)
                           .order("name, latitude DESC").limit(100)
       if @bus_stops.empty?
-        client = GooglePlaces::Client.new(ENV["GOOGLE_API_KEY"])
+        client = GooglePlaces::Client.new(ENV["GOOGLE_PLACES_API_KEY"])
         spots = Rails.cache.fetch(params[:q]) do
           # The maximum allowed radius is 50,000 meters in Google Places API Web Service
           # 千葉県庁@35.6049233,140.1208483

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -18,7 +18,7 @@
     <%= javascript_include_tag 'application', 'data-turbolinks-track' => true %>
     <%= csrf_meta_tags %>
     <%= analytics_init if GoogleAnalytics.valid_tracker? %>
-    <script src="//maps.google.com/maps/api/js?key=<%= ENV["GOOGLE_MAPS_API_KEY"] %>&libraries=geometry"></script>
+    <script src="//maps.google.com/maps/api/js?key=<%= ENV["GOOGLE_MAPS_JS_API_KEY"] %>&libraries=geometry"></script>
     <script src="//cdn.rawgit.com/mahnunchik/markerclustererplus/master/dist/markerclusterer.min.js"></script>
     <%= javascript_importmap_tags "main" %>
   </head>

--- a/config/initializers/geocoder.rb
+++ b/config/initializers/geocoder.rb
@@ -7,7 +7,6 @@ Geocoder.configure(
   # http_proxy: nil,            # HTTP proxy server (user:pass@host:port)
   # https_proxy: nil,           # HTTPS proxy server (user:pass@host:port)
   # api_key: nil,               # API key for geocoding service
-  api_key: ENV["GOOGLE_API_KEY"], # API key for geocoding service
   # cache: nil,                 # cache object (must respond to #[], #[]=, and #keys)
   # cache_prefix: 'geocoder:',  # prefix (string) to use for all cache keys
 


### PR DESCRIPTION
## Summary
- `GOOGLE_API_KEY` → `GOOGLE_PLACES_API_KEY` にリネーム。実際に使っているのは `GooglePlaces::Client.new(...)` のみで、汎用名だと今後 Maps 系 / Geocoding 系の鍵を増やした時に混同しやすいため
- `GOOGLE_MAPS_API_KEY` → `GOOGLE_MAPS_JS_API_KEY` にリネーム。Google Maps Platform にはサーバーサイド製品 (Geocoding / Directions / Distance Matrix / Maps Static など) も多数あり、`MAPS_API_KEY` だけだとフロント用かサーバー用か曖昧。Cloud Console 上の API 名 (Maps JavaScript API) ともそろう
- `config/initializers/geocoder.rb` の `api_key: ENV["GOOGLE_API_KEY"]` を削除。Geocoding は ISJ オフラインデータに移行済みで Geocoder gem 経由の API 呼び出しは無く、実質 dead config だった
- README / CLAUDE.md / CI workflow も新しい環境変数名に追従

## マージ前にユーザー側で必要な対応
- [ ] Heroku の config var に `GOOGLE_PLACES_API_KEY` / `GOOGLE_MAPS_JS_API_KEY` を追加 (旧キー値をそのままコピーしてよい): `heroku config:set GOOGLE_PLACES_API_KEY=$(heroku config:get GOOGLE_API_KEY) GOOGLE_MAPS_JS_API_KEY=$(heroku config:get GOOGLE_MAPS_API_KEY)`

## Test plan
- [x] マージ後、本番で `/bus_routes/:id` の地図が表示されること (Maps JS 鍵)
- [x] マージ後、本番で DB ヒット 0 件のクエリ (例: `?q=スターバックス渋谷`) で Places フォールバック結果が返ること (Places 鍵、サーバーサイド呼び出しなので Cloud Console 側で application restriction が None になっていることも要確認)
- [ ] 動作確認後、旧 Heroku config var を削除: `heroku config:unset GOOGLE_API_KEY GOOGLE_MAPS_API_KEY`