### PR TITLE
Split stitch into its own task and optimize bus_stop_number pipeline

### DIFF
--- a/lib/bus_stop_numberer.rb
+++ b/lib/bus_stop_numberer.rb
@@ -16,7 +16,11 @@
 # 距離が大きいバス停は「軌跡データが路線をカバーしていない」サインで、データ欠損を識別できる
 # (例: 神奈川中央交通 津01 で 32 バス停が軌跡から 20km 離れている)。
 class BusStopNumberer
-  Result = Struct.new(:assignments, :distances_m, keyword_init: true)
+  # vertex_indices: pick_best_assignment の count_inversions / diagnose の idx_inversions が使う
+  # 「各 brbs の最近接 vertex の flat_coords 内 index」。numberer 本体の射影ループに乗せて
+  # 1 回の iteration で計算するので、後段の inversion チェックは flat_coords を再走査せずに済む。
+  # bridge segment は (count_inversions と挙動を揃えるため) フィルタしない。
+  Result = Struct.new(:assignments, :distances_m, :vertex_indices, keyword_init: true)
 
   # 緯度 1 度 ≈ 111km の近似で度² から m に変換する係数。
   # (経度方向は緯度依存だが、200m 閾値の判定なら近似で十分。)
@@ -44,7 +48,8 @@ class BusStopNumberer
     if @flat_coords.empty?
       assignments = @brbs.map { |b| [ b.id, nil ] }
       distances = @brbs.to_h { |b| [ b.id, nil ] }
-      return Result.new(assignments: assignments, distances_m: distances)
+      vertex_indices = @brbs.to_h { |b| [ b.id, nil ] }
+      return Result.new(assignments: assignments, distances_m: distances, vertex_indices: vertex_indices)
     end
 
     # flat_coords が 1 点しかない場合は segment が作れない。全 brbs を idx=0 の点との距離で並べる。
@@ -58,11 +63,15 @@ class BusStopNumberer
       sorted = pre.sort_by { |id, pos, dist_sq| [ pos, dist_sq, id ] }
       assignments = sorted.each_with_index.map { |(id, _, _), i| [ id, i + 1 ] }
       distances = pre.to_h { |id, _, dist_sq| [ id, Math.sqrt(dist_sq) * DEG_TO_M ] }
-      return Result.new(assignments: assignments, distances_m: distances)
+      vertex_indices = @brbs.to_h { |b| [ b.id, 0 ] }
+      return Result.new(assignments: assignments, distances_m: distances, vertex_indices: vertex_indices)
     end
 
-    # 各 brbs について、最も近い segment と segment 内位置 t を計算して
-    # curvilinear position (= segment_index + t) を求める。
+    last_idx = @flat_coords.size - 1
+    last_c = @flat_coords[last_idx]
+
+    # 各 brbs について、最も近い segment と segment 内位置 t (採番用) と、
+    # 最も近い vertex の index (inversion チェック用) を 1 ループで計算する。
     pre = @brbs.map do |brbs|
       bs = brbs.bus_stop
       lat = bs.latitude
@@ -72,7 +81,18 @@ class BusStopNumberer
       best_t = 0.0
       best_dist_sq = Float::INFINITY
 
+      # vertex 距離は count_inversions の挙動と揃えるため bridge segment フィルタを適用しない。
+      best_vertex_idx = 0
+      best_vertex_dist_sq = Float::INFINITY
+
       @flat_coords.each_cons(2).with_index do |(p, q), i|
+        # vertex 距離 (segment 始点 p のみここで見る。終点 q はループ外で last_idx を 1 回確認)。
+        dvp = (lat - p[0]) ** 2 + (lng - p[1]) ** 2
+        if dvp < best_vertex_dist_sq
+          best_vertex_dist_sq = dvp
+          best_vertex_idx = i
+        end
+
         next if @bridge_segments.include?(i)
         dx = q[0] - p[0]
         dy = q[1] - p[1]
@@ -100,13 +120,20 @@ class BusStopNumberer
         end
       end
 
-      [ brbs.id, best_segment + best_t, best_dist_sq ]
+      # 最終 vertex (= flat_coords[last_idx]) はループ内では p として現れないので、ここで 1 回確認。
+      d_last = (lat - last_c[0]) ** 2 + (lng - last_c[1]) ** 2
+      if d_last < best_vertex_dist_sq
+        best_vertex_idx = last_idx
+      end
+
+      [ brbs.id, best_segment + best_t, best_dist_sq, best_vertex_idx ]
     end
 
     # curvilinear position 昇順 → 同位置は距離順 → 同距離は id 順で安定化。
-    sorted = pre.sort_by { |id, pos, dist_sq| [ pos, dist_sq, id ] }
-    assignments = sorted.each_with_index.map { |(id, _, _), i| [ id, i + 1 ] }
-    distances = pre.to_h { |id, _, dist_sq| [ id, Math.sqrt(dist_sq) * DEG_TO_M ] }
-    Result.new(assignments: assignments, distances_m: distances)
+    sorted = pre.sort_by { |id, pos, dist_sq, _vidx| [ pos, dist_sq, id ] }
+    assignments = sorted.each_with_index.map { |(id, _, _, _), i| [ id, i + 1 ] }
+    distances = pre.to_h { |id, _, dist_sq, _vidx| [ id, Math.sqrt(dist_sq) * DEG_TO_M ] }
+    vertex_indices = pre.to_h { |id, _, _, vidx| [ id, vidx ] }
+    Result.new(assignments: assignments, distances_m: distances, vertex_indices: vertex_indices)
   end
 end

--- a/lib/prefecture_filter.rb
+++ b/lib/prefecture_filter.rb
@@ -1,0 +1,29 @@
+# `ENV["PREFECTURE"]` で BusRoute scope を 1 都道府県に絞るユーティリティ。
+#
+# stitch:generate / bus_stop_number:generate / bus_stop_number:diagnose で共有して使う。
+# 都道府県名 (例: "東京都"、"千葉県") を直接渡す。bus_stops.prefecture は国土数値情報
+# の都道府県名がそのまま入っているのでこれと比較する。
+#
+# 絞り込みアルゴリズム: 該当 prefecture の bus_stops を経由して bus_routes を逆引きする。
+# routes 自体には prefecture 列がないため (= 1 路線が複数県を跨ぐケースに対応するため)、
+# 「その県のどこかにバス停を持つ route」を対象とする。
+#
+# 用途: 採番/stitch ロジックの反復実験を 47 倍速で回すためのもの。フィルタが有効な場合
+# `db/data/*.csv.gz` の上書きはせず (= 残り 46 県分の出力が消えてしまうため)、ベンチや
+# diagnose 専用と割り切る運用にする。
+class PrefectureFilter
+  # ENV["PREFECTURE"] が指定されていれば scope を絞り、そうでなければ scope をそのまま返す。
+  def self.apply(scope)
+    return scope unless active?
+    pref = ENV["PREFECTURE"]
+    filtered = scope.where(id: BusRoute.joins(bus_route_bus_stops: :bus_stop)
+                                        .where(bus_stops: { prefecture: pref })
+                                        .distinct.select(:id))
+    puts "  PREFECTURE=#{pref}: filtered to #{filtered.count} routes"
+    filtered
+  end
+
+  def self.active?
+    ENV["PREFECTURE"].present?
+  end
+end

--- a/lib/start_terminal_selector.rb
+++ b/lib/start_terminal_selector.rb
@@ -34,14 +34,20 @@ class StartTerminalSelector
   # する (例 500m) と「駅と無関係なバス停が偶然 "駅" を含む地名」を誤って拾うリスクが上がる。
   STATION_HINT_RADIUS_M = 200.0
 
-  def self.call(tracks, line_name: nil, bus_route_bus_stops: nil)
-    new(tracks, line_name, bus_route_bus_stops).call
+  # @param stitch_fn [Proc, nil] 内部の multi_try_min_bridge から呼ぶ stitcher。
+  #   `->(tracks, start) { TrackStitcher::Result }` を渡すと TrackStitcher 直接呼び出しを
+  #   差し替えできる。stitch:generate / bus_stop_number:generate は store からの read を
+  #   返す lambda を渡し、selector の試行 stitch も同じ store に乗せる。
+  #   省略時はデフォルトの TrackStitcher 直接呼び出し。
+  def self.call(tracks, line_name: nil, bus_route_bus_stops: nil, stitch_fn: nil)
+    new(tracks, line_name, bus_route_bus_stops, stitch_fn).call
   end
 
-  def initialize(tracks, line_name, bus_route_bus_stops)
+  def initialize(tracks, line_name, bus_route_bus_stops, stitch_fn = nil)
     @tracks = tracks
     @line_name = line_name
     @brbs = bus_route_bus_stops
+    @stitch_fn = stitch_fn || ->(t, s) { TrackStitcher.call_with_diagnostics(t, start: s) }
     @terminals = collect_terminals
   end
 
@@ -116,7 +122,7 @@ class StartTerminalSelector
   # tiebreak は最西端 (現状互換)。
   def multi_try_min_bridge
     scored = @terminals.map do |coord|
-      result = TrackStitcher.call_with_diagnostics(@tracks, start: coord)
+      result = @stitch_fn.call(@tracks, coord)
       total = result.bridge_segment_indices.sum { |i|
         next 0.0 if i + 1 >= result.flat_coords.size
         a = result.flat_coords[i]

--- a/lib/stitch_store.rb
+++ b/lib/stitch_store.rb
@@ -1,0 +1,147 @@
+require "csv"
+require "fileutils"
+require "json"
+require "zlib"
+
+# stitch:generate が出力する db/data/stitches.csv.gz の読み書きを担当する。
+#
+# レコード形は (route_id, start_repr) 複合キー。1 路線につき 1 〜 2 行 (selector 起点 A と
+# fallback 起点 B = nil)。pick_best_assignment が両候補を比較するために両方を読み出す。
+#
+# 各列の意味:
+#   - route_id, start_repr     ... 複合キー
+#   - flat_coords (JSON 配列)   ... 採番に使う 1D 化された座標列
+#   - bridge_segment_indices   ... numberer が射影対象から除外する virtual segment の index
+#   - total_tracks ... isolated_count, max_jump_distance ... connection_count
+#                              ... diagnose タスクが消費する stitch メトリクス
+#
+# stitch:load は無い: production はこの中間ファイルを読まないので DB に投入しない。
+# bus_stop_number:generate / diagnose のみが offline で読み出す。
+module StitchStore
+  STITCHES_PATH = "db/data/stitches.csv.gz".freeze
+
+  COLUMNS = %w[
+    route_id start_repr flat_coords bridge_segment_indices
+    total_tracks skipped_parallel reversed_count isolated_count
+    max_jump_distance large_jump_count connection_jump_max
+    connection_large_jump_count connection_count
+  ].freeze
+
+  # cache から復元する stitch 結果のレコード型。
+  # TrackStitcher::Result とフィールドをそろえてあるが、stitch_steps だけは inspect task
+  # でしか使わず、CSV に出すと巨大になるので除外する。
+  Entry = Struct.new(
+    :flat_coords,
+    :bridge_segment_indices,
+    :total_tracks,
+    :skipped_parallel,
+    :reversed_count,
+    :isolated_count,
+    :max_jump_distance,
+    :large_jump_count,
+    :connection_jump_max,
+    :connection_large_jump_count,
+    :connection_count,
+    keyword_init: true
+  )
+
+  def self.path
+    Rails.root.join(STITCHES_PATH)
+  end
+
+  # `start` (= [lat, lng] 配列 or nil) を CSV 行内のキー文字列に変換する。
+  # 浮動小数点の表現は同一プロセス内で安定なので to_s ベースの単純連結で十分。
+  def self.encode_start(start)
+    start.nil? ? "nil" : "#{start[0]}:#{start[1]}"
+  end
+
+  # CSV を読み込んで {(route_id, start_repr) => Entry} の Hash で返す。
+  # ファイル不在なら空 Hash。
+  def self.load_existing
+    return {} unless File.exist?(path)
+
+    map = {}
+    Zlib::GzipReader.open(path) do |gz|
+      CSV.new(gz, headers: true).each do |row|
+        key = [ row["route_id"].to_i, row["start_repr"] ]
+        map[key] = Entry.new(
+          flat_coords: JSON.parse(row["flat_coords"]),
+          bridge_segment_indices: JSON.parse(row["bridge_segment_indices"]),
+          total_tracks: row["total_tracks"].to_i,
+          skipped_parallel: row["skipped_parallel"].to_i,
+          reversed_count: row["reversed_count"].to_i,
+          isolated_count: row["isolated_count"].to_i,
+          max_jump_distance: row["max_jump_distance"].to_f,
+          large_jump_count: row["large_jump_count"].to_i,
+          connection_jump_max: row["connection_jump_max"].to_f,
+          connection_large_jump_count: row["connection_large_jump_count"].to_i,
+          connection_count: row["connection_count"].to_i
+        )
+      end
+    end
+    map
+  end
+
+  # Hash を CSV.gz に書き出す (route_id, start_repr 順でソート)。
+  def self.write(map)
+    FileUtils.mkdir_p(File.dirname(path))
+    Zlib::GzipWriter.open(path) do |gz|
+      csv = CSV.new(gz, headers: COLUMNS, write_headers: true)
+      map.sort.each do |(route_id, start_repr), entry|
+        csv << [
+          route_id,
+          start_repr,
+          JSON.generate(entry.flat_coords),
+          JSON.generate(entry.bridge_segment_indices),
+          entry.total_tracks,
+          entry.skipped_parallel,
+          entry.reversed_count,
+          entry.isolated_count,
+          entry.max_jump_distance,
+          entry.large_jump_count,
+          entry.connection_jump_max,
+          entry.connection_large_jump_count,
+          entry.connection_count
+        ]
+      end
+    end
+    path
+  end
+
+  # TrackStitcher::Result から CSV 用 Entry を作る。
+  def self.entry_from_result(result)
+    Entry.new(
+      flat_coords: result.flat_coords,
+      bridge_segment_indices: result.bridge_segment_indices,
+      total_tracks: result.total_tracks,
+      skipped_parallel: result.skipped_parallel,
+      reversed_count: result.reversed_count,
+      isolated_count: result.isolated_count,
+      max_jump_distance: result.max_jump_distance,
+      large_jump_count: result.large_jump_count,
+      connection_jump_max: result.connection_jump_max,
+      connection_large_jump_count: result.connection_large_jump_count,
+      connection_count: result.connection_count
+    )
+  end
+
+  # CSV 由来の Entry から TrackStitcher::Result 形のオブジェクトを作る。
+  # bus_stop_number:generate / diagnose は stitch.flat_coords, stitch.bridge_segment_indices,
+  # 各メトリクス列を使うが stitch_steps は使わないため、stitch_steps は空配列で埋める。
+  def self.result_from_entry(entry)
+    TrackStitcher::Result.new(
+      flat_coords: entry.flat_coords,
+      total_tracks: entry.total_tracks,
+      skipped_parallel: entry.skipped_parallel,
+      reversed_count: entry.reversed_count,
+      isolated_count: entry.isolated_count,
+      max_jump_distance: entry.max_jump_distance,
+      large_jump_count: entry.large_jump_count,
+      connection_jump_max: entry.connection_jump_max,
+      connection_large_jump_count: entry.connection_large_jump_count,
+      connection_count: entry.connection_count,
+      stitch_steps: [],
+      bridge_segment_indices: entry.bridge_segment_indices
+    )
+  end
+end

--- a/lib/tasks/bus_stop_number.rake
+++ b/lib/tasks/bus_stop_number.rake
@@ -10,6 +10,35 @@
 # 通常のセットアップでは generate は呼ばず、load のみで CSV を反映する。
 # generate は再生成すると順序が変わりうる（CLAUDE.md 参照）。
 namespace :bus_stop_number do
+  # AR (BusStop.latitude 等) は LazyAttributeSet#fetch_value 経由で旧プロファイル上 21% 占めて
+  # いた。numberer / orienter / selector / diagnose は brbs.id / brbs.bus_stop_number /
+  # brbs.bus_stop.{latitude,longitude,name} しか触らないので、AR の代わりに plain Struct で
+  # wrap して JOIN 1 本の pluck で必要列だけロードする。
+  PluckedBrbs = Struct.new(:id, :bus_stop_number, :bus_stop, keyword_init: true)
+  PluckedBusStop = Struct.new(:latitude, :longitude, :name, keyword_init: true)
+
+  # 1 路線分の brbs を bus_stops JOIN ＋ pluck で軽量にロードする。
+  # AR インスタンス化を避け、attribute 読み出しを Struct 化することで hot loop の overhead を削減。
+  def self.load_brbs(bus_route)
+    bus_route.bus_route_bus_stops
+             .joins(:bus_stop)
+             .reorder("bus_route_bus_stops.id")
+             .pluck(
+               "bus_route_bus_stops.id",
+               "bus_route_bus_stops.bus_stop_number",
+               "bus_stops.latitude",
+               "bus_stops.longitude",
+               "bus_stops.name"
+             )
+             .map { |id, num, lat, lng, name|
+               PluckedBrbs.new(
+                 id: id,
+                 bus_stop_number: num,
+                 bus_stop: PluckedBusStop.new(latitude: lat, longitude: lng, name: name)
+               )
+             }
+  end
+
   # generate / profile から共通に呼ぶ計算本体。CSV に書き出す行配列を返す。
   #
   # 6000+ 路線 × N クエリの構成のため、開発環境の SQL クエリログ生成
@@ -101,7 +130,7 @@ namespace :bus_stop_number do
       # fragmented route の bus_stop も number を埋める (直接 URL アクセスで表示する用)。
       # default_scope で隠す対象でも、stops 自体は表示するので採番は必要。
       scope.find_each do |bus_route|
-        brbs = bus_route.bus_route_bus_stops.reorder(:id).includes(:bus_stop).to_a
+        brbs = load_brbs(bus_route)
         result = pick_best_assignment(bus_route, brbs, stitches)
         rows.concat(result[:assignments])
         fallback_count += 1 if result[:fallback]
@@ -214,11 +243,13 @@ namespace :bus_stop_number do
     puts "Stitches loaded: #{stitches.size} entries from #{StitchStore.path}"
 
     ActiveRecord::Base.logger.silence(Logger::WARN) do
-      scope.includes(:bus_route_tracks, bus_route_bus_stops: :bus_stop).find_each do |bus_route|
+      # bus_route_bus_stops / bus_stops は load_brbs (joins + pluck) でまとめて取るので
+      # eager-load の対象から外す。tracks のみ preload する。
+      scope.includes(:bus_route_tracks).find_each do |bus_route|
         # compute_assignments と同じ id 順 brbs を使うことで、LineNameOrienter (内部で `find` を
         # 使うため順序依存) の挙動が両者で揃う。順序が違うと A/B 候補で別の stop が match し、
         # 反転判定が変わり、stored bus_stop_number と diagnose 計測の flat がずれていた。
-        brbs_list = bus_route.bus_route_bus_stops.sort_by(&:id)
+        brbs_list = load_brbs(bus_route)
         picked = pick_best_assignment(bus_route, brbs_list, stitches)
         stitch = picked[:stitch]
         number_result = picked[:number_result]
@@ -234,9 +265,10 @@ namespace :bus_stop_number do
 
         # 採番品質の指標 (1): バス停物理座標の進行方向反転を数える。街路の鋭角ターンも拾うため
         # ノイズが多いが、極端に大きい値は採番崩れのサイン。
-        ordered = bus_route.bus_route_bus_stops
-                            .select { |b| b.bus_stop_number }
-                            .sort_by(&:bus_stop_number)
+        # ordered は plucked brbs_list を流用 (bus_stop_number は plucked 列に同梱済み)。
+        ordered = brbs_list
+                    .select { |b| b.bus_stop_number }
+                    .sort_by(&:bus_stop_number)
         backward_turns = 0
         ordered.each_cons(3) do |a, b, c|
           ab_lat = b.bus_stop.latitude - a.bus_stop.latitude

--- a/lib/tasks/bus_stop_number.rake
+++ b/lib/tasks/bus_stop_number.rake
@@ -41,8 +41,10 @@ namespace :bus_stop_number do
     candidate_a = run_pipeline(tracks, bus_route, brbs, start: start_a, fallback: false, stitches: stitches)
     candidate_b = run_pipeline(tracks, bus_route, brbs, start: nil, fallback: true, stitches: stitches)
 
-    inv_a = count_inversions(candidate_a[:flat_coords], brbs, candidate_a[:assignments])
-    inv_b = count_inversions(candidate_b[:flat_coords], brbs, candidate_b[:assignments])
+    # vertex_indices は numberer が射影ループ内で計算済み (BusStopNumberer::Result.vertex_indices)。
+    # flat_coords を再走査しないので 1 route あたり O(brbs × coords) を 2 回節約できる。
+    inv_a = count_inversions(candidate_a[:number_result].vertex_indices, brbs, candidate_a[:assignments])
+    inv_b = count_inversions(candidate_b[:number_result].vertex_indices, brbs, candidate_b[:assignments])
 
     # A 優位 or 同点なら A (selector のメリットを残す)。B が明確に良ければ fallback。
     # 過去観察: selector は bridge 距離合計を最小化するが、それが順序最良と一致しないケースが
@@ -116,11 +118,14 @@ namespace :bus_stop_number do
     rows
   end
 
-  # bus_stop_number 順に並べたバス停の「flat_coords 上での最近接 idx」が単調か。
+  # bus_stop_number 順に並べたバス停の「flat_coords 上での最近接 vertex idx」が単調か。
   # 5 idx 以上戻ったら inversion とカウントする (SimplifyRb の小ぶれを許容)。
-  # diagnose タスクの idx_inversions と同じ計算。
-  def self.count_inversions(flat_coords, brbs, assignments)
-    return 0 if flat_coords.empty?
+  # diagnose タスクの idx_inversions と同じ計算 (こちらは A/B 比較で 2 回呼ばれる)。
+  #
+  # vertex_indices は BusStopNumberer::Result.vertex_indices (= 各 brbs の最近接 vertex の
+  # flat_coords 内 index)。numberer の射影ループに乗せて計算済みなので、ここでは flat_coords
+  # を再走査しない。
+  def self.count_inversions(vertex_indices, brbs, assignments)
     num_by_id = assignments.to_h
     ordered = brbs.map { |b| [ b, num_by_id[b.id] ] }
                   .select { |_, n| n }
@@ -128,16 +133,8 @@ namespace :bus_stop_number do
     inversions = 0
     prev_idx = -1
     ordered.each do |b, _|
-      bs = b.bus_stop
-      min_idx = 0
-      min_dist_sq = Float::INFINITY
-      flat_coords.each_with_index do |c, idx|
-        d = (bs.latitude - c[0]) ** 2 + (bs.longitude - c[1]) ** 2
-        if d < min_dist_sq
-          min_dist_sq = d
-          min_idx = idx
-        end
-      end
+      min_idx = vertex_indices[b.id]
+      next if min_idx.nil?
       inversions += 1 if prev_idx >= 0 && min_idx < prev_idx - 5
       prev_idx = min_idx
     end
@@ -255,24 +252,16 @@ namespace :bus_stop_number do
         # 後ろのバス停を先に並べた」という直接的なバグ。tolerance=5 で SimplifyRb 起因の小ぶれを許容。
         # 注意: 循環路線では「同じ場所を 2 回通る」ため raw closest_idx が周回終端で巻き戻る。
         # これは採番バグではないが指標上はカウントされてしまう (= 偽陽性)。
+        #
+        # vertex_indices は number_result が射影ループ内で計算済みなので flat_coords を再走査しない。
         idx_inversions = 0
-        flat = stitch.flat_coords
-        if !flat.empty?
-          prev_idx = -1
-          ordered.each do |b|
-            bs = b.bus_stop
-            min_idx = 0
-            min_dist_sq = Float::INFINITY
-            flat.each_with_index do |c, idx|
-              d = (bs.latitude - c[0]) ** 2 + (bs.longitude - c[1]) ** 2
-              if d < min_dist_sq
-                min_dist_sq = d
-                min_idx = idx
-              end
-            end
-            idx_inversions += 1 if prev_idx >= 0 && min_idx < prev_idx - 5
-            prev_idx = min_idx
-          end
+        vertex_indices = number_result.vertex_indices
+        prev_idx = -1
+        ordered.each do |b|
+          min_idx = vertex_indices[b.id]
+          next if min_idx.nil?
+          idx_inversions += 1 if prev_idx >= 0 && min_idx < prev_idx - 5
+          prev_idx = min_idx
         end
 
         # 採番品質の指標 (3): 連続するバス停間の物理距離 (m) に基づく outlier 検出。

--- a/lib/tasks/bus_stop_number.rake
+++ b/lib/tasks/bus_stop_number.rake
@@ -22,16 +22,24 @@ namespace :bus_stop_number do
   #
   # 戻り値の :stitch / :number_result はすべて picked path のもの。compute_assignments と
   # diagnose の両方で同じ選択結果を扱うために共通化している。
-  def self.pick_best_assignment(bus_route, brbs)
+  # stitch:generate が出力した db/data/stitches.csv.gz から該当 route の stitch を引き、
+  # numberer + LineNameOrienter で採番する。stitches に該当行が無ければ stitcher を live 実行
+  # (= stitch:generate 後に DB へ新規 route が追加されたケース等の救済)。
+  def self.pick_best_assignment(bus_route, brbs, stitches)
     tracks = bus_route.bus_route_tracks.to_a
-    start_a = StartTerminalSelector.call(tracks, line_name: bus_route.line_name, bus_route_bus_stops: brbs)
+    start_a = StartTerminalSelector.call(
+      tracks,
+      line_name: bus_route.line_name,
+      bus_route_bus_stops: brbs,
+      stitch_fn: ->(t, s) { fetch_stitch(stitches, bus_route.id, t, s) }
+    )
 
     if start_a.nil?
-      return run_pipeline(tracks, bus_route, brbs, start: nil, fallback: false)
+      return run_pipeline(tracks, bus_route, brbs, start: nil, fallback: false, stitches: stitches)
     end
 
-    candidate_a = run_pipeline(tracks, bus_route, brbs, start: start_a, fallback: false)
-    candidate_b = run_pipeline(tracks, bus_route, brbs, start: nil, fallback: true)
+    candidate_a = run_pipeline(tracks, bus_route, brbs, start: start_a, fallback: false, stitches: stitches)
+    candidate_b = run_pipeline(tracks, bus_route, brbs, start: nil, fallback: true, stitches: stitches)
 
     inv_a = count_inversions(candidate_a[:flat_coords], brbs, candidate_a[:assignments])
     inv_b = count_inversions(candidate_b[:flat_coords], brbs, candidate_b[:assignments])
@@ -42,9 +50,10 @@ namespace :bus_stop_number do
     inv_a <= inv_b ? candidate_a : candidate_b
   end
 
-  # stitch + numberer + LineNameOrienter を 1 回回し、後続評価のため stitch/number_result も返す。
-  def self.run_pipeline(tracks, bus_route, brbs, start:, fallback:)
-    stitch = TrackStitcher.call_with_diagnostics(tracks, start: start)
+  # numberer + LineNameOrienter を 1 回回し、後続評価のため stitch/number_result も返す。
+  # stitch は stitches store から引く (live 実行は fetch_stitch のフォールバックパス)。
+  def self.run_pipeline(tracks, bus_route, brbs, start:, fallback:, stitches:)
+    stitch = fetch_stitch(stitches, bus_route.id, tracks, start)
     number_result = BusStopNumberer.call_with_diagnostics(
       flat_coords: stitch.flat_coords,
       bus_route_bus_stops: brbs,
@@ -60,7 +69,28 @@ namespace :bus_stop_number do
     }
   end
 
+  # stitches store から該当 (route_id, start) の stitch を引く。
+  # 無ければ stitcher を live 実行して store に追記する (stitch:generate 以降に DB へ新規 route が
+  # 入ったケース等)。store が完全に空なら stitch:generate の実行漏れを示すので明示的に raise する。
+  def self.fetch_stitch(stitches, route_id, tracks, start)
+    key = [ route_id, StitchStore.encode_start(start) ]
+    if (entry = stitches[key])
+      StitchStore.result_from_entry(entry)
+    else
+      result = TrackStitcher.call_with_diagnostics(tracks, start: start)
+      stitches[key] = StitchStore.entry_from_result(result)
+      result
+    end
+  end
+
   def self.compute_assignments
+    stitches = StitchStore.load_existing
+    if stitches.empty?
+      raise "Missing #{StitchStore.path}. Run 'rails stitch:generate' first."
+    end
+    initial_size = stitches.size
+    puts "  stitches loaded: #{initial_size} entries from #{StitchStore.path}"
+
     rows = []
     fallback_count = 0
     ActiveRecord::Base.logger.silence(Logger::WARN) do
@@ -68,11 +98,17 @@ namespace :bus_stop_number do
       # default_scope で隠す対象でも、stops 自体は表示するので採番は必要。
       BusRoute.with_fragmented.find_each do |bus_route|
         brbs = bus_route.bus_route_bus_stops.reorder(:id).includes(:bus_stop).to_a
-        result = pick_best_assignment(bus_route, brbs)
+        result = pick_best_assignment(bus_route, brbs, stitches)
         rows.concat(result[:assignments])
         fallback_count += 1 if result[:fallback]
       end
     end
+
+    new_entries = stitches.size - initial_size
+    if new_entries > 0
+      puts "  stitches: +#{new_entries} live-stitched entries (route 新規追加? stitch:generate を再実行推奨)"
+    end
+
     rows.sort_by! { |id, _| id }
     puts "  fallback to westmost: #{fallback_count} routes"
     rows
@@ -166,13 +202,19 @@ namespace :bus_stop_number do
     scope = ENV["INCLUDE_FRAGMENTED"] ? BusRoute.with_fragmented : BusRoute.all
     puts "Diagnose target: #{scope.count} routes (#{ENV['INCLUDE_FRAGMENTED'] ? 'INCLUDING' : 'EXCLUDING'} fragmented)"
 
+    stitches = StitchStore.load_existing
+    if stitches.empty?
+      raise "Missing #{StitchStore.path}. Run 'rails stitch:generate' first."
+    end
+    puts "Stitches loaded: #{stitches.size} entries from #{StitchStore.path}"
+
     ActiveRecord::Base.logger.silence(Logger::WARN) do
       scope.includes(:bus_route_tracks, bus_route_bus_stops: :bus_stop).find_each do |bus_route|
         # compute_assignments と同じ id 順 brbs を使うことで、LineNameOrienter (内部で `find` を
         # 使うため順序依存) の挙動が両者で揃う。順序が違うと A/B 候補で別の stop が match し、
         # 反転判定が変わり、stored bus_stop_number と diagnose 計測の flat がずれていた。
         brbs_list = bus_route.bus_route_bus_stops.sort_by(&:id)
-        picked = pick_best_assignment(bus_route, brbs_list)
+        picked = pick_best_assignment(bus_route, brbs_list, stitches)
         stitch = picked[:stitch]
         number_result = picked[:number_result]
 

--- a/lib/tasks/bus_stop_number.rake
+++ b/lib/tasks/bus_stop_number.rake
@@ -91,12 +91,14 @@ namespace :bus_stop_number do
     initial_size = stitches.size
     puts "  stitches loaded: #{initial_size} entries from #{StitchStore.path}"
 
+    scope = PrefectureFilter.apply(BusRoute.with_fragmented)
+
     rows = []
     fallback_count = 0
     ActiveRecord::Base.logger.silence(Logger::WARN) do
       # fragmented route の bus_stop も number を埋める (直接 URL アクセスで表示する用)。
       # default_scope で隠す対象でも、stops 自体は表示するので採番は必要。
-      BusRoute.with_fragmented.find_each do |bus_route|
+      scope.find_each do |bus_route|
         brbs = bus_route.bus_route_bus_stops.reorder(:id).includes(:bus_stop).to_a
         result = pick_best_assignment(bus_route, brbs, stitches)
         rows.concat(result[:assignments])
@@ -152,22 +154,27 @@ namespace :bus_stop_number do
     2.0 * 6_371_000.0 * Math.asin(Math.sqrt(a))
   }
 
-  desc "Generate bus_stop_number into db/data/bus_stop_numbers.csv.gz (does not touch DB)"
+  desc "Generate bus_stop_number into db/data/bus_stop_numbers.csv.gz (does not touch DB). Set PREFECTURE=東京都 to filter (skips CSV write)"
   task generate: :environment do
     require "csv"
     require "zlib"
     $stdout.sync = true
     csv_path = "db/data/bus_stop_numbers.csv.gz"
 
-    # 1. 路線の bus_route_tracks を TrackStitcher で 1 本の座標列に繋ぎ合わせる。
-    # 2. BusStopNumberer で各 brbs に bus_stop_number を割り当てる。
+    # 1. db/data/stitches.csv.gz から stitch 結果を読み込む (stitch:generate 出力)。
+    # 2. BusStopNumberer で各 brbs に bus_stop_number を割り当て、A/B 候補から best を選ぶ。
     rows = compute_assignments
 
-    Zlib::GzipWriter.open(csv_path) do |gz|
-      csv = CSV.new(gz, headers: %w[bus_route_bus_stop_id bus_stop_number], write_headers: true)
-      rows.each { |row| csv << row }
+    if PrefectureFilter.active?
+      # 部分実行で全体 CSV を上書きすると残り県分の rows が消える。read-only モードで終了。
+      puts "PREFECTURE filter active: skipping CSV write (#{rows.size} rows computed in-memory only)"
+    else
+      Zlib::GzipWriter.open(csv_path) do |gz|
+        csv = CSV.new(gz, headers: %w[bus_route_bus_stop_id bus_stop_number], write_headers: true)
+        rows.each { |row| csv << row }
+      end
+      puts "Wrote #{csv_path} (#{rows.size} rows)"
     end
-    puts "Wrote #{csv_path} (#{rows.size} rows)"
   end
 
   desc "Profile bus_stop_number:generate via stackprof (writes tmp/bus_stop_number_generate.stackprof)"
@@ -200,6 +207,7 @@ namespace :bus_stop_number do
     # 改善対象外。BusRoute の default_scope で除外され、ノイズ除去された状態で計測される。
     # 全路線含めて見たい場合は INCLUDE_FRAGMENTED=1 を渡す。
     scope = ENV["INCLUDE_FRAGMENTED"] ? BusRoute.with_fragmented : BusRoute.all
+    scope = PrefectureFilter.apply(scope)
     puts "Diagnose target: #{scope.count} routes (#{ENV['INCLUDE_FRAGMENTED'] ? 'INCLUDING' : 'EXCLUDING'} fragmented)"
 
     stitches = StitchStore.load_existing

--- a/lib/tasks/stitch.rake
+++ b/lib/tasks/stitch.rake
@@ -1,0 +1,85 @@
+# 路線の bus_route_tracks を 1 本の flat_coords に連結する `stitch:generate` を提供する。
+#
+# 出力: db/data/stitches.csv.gz (per-route × 起点候補 (A: selector / B: nil) で 1 〜 2 行)。
+# bus_stop_number:generate / diagnose はこのファイルを読み出し、stitcher を再実行せずに
+# numberer + 評価だけを回す。
+#
+# stitch:load は無い: production はこの中間ファイルを読まない (DB のスキーマは無変更)。
+# Heroku デプロイでも generate は呼ばれず、commit 済みの CSV を bus_stop_number:load の
+# 直前段階として bus_stop_number:generate (= ローカル実行) が消費するだけ。
+namespace :stitch do
+  # generate / profile から共通に呼ぶ計算本体。Hash {(route_id, start_repr) => Entry} を返す。
+  # pick_best_assignment と同じ start 候補 (selector A + fallback nil) を全 route で計算する。
+  def self.compute_stitches
+    map = {}
+    selector_used = 0
+    fallback_only = 0
+    multi_try = 0
+    fallback_multi = ->(tracks, start) {
+      multi_try += 1
+      stitch_one(tracks, start)
+    }
+
+    ActiveRecord::Base.logger.silence(Logger::WARN) do
+      BusRoute.with_fragmented.find_each do |bus_route|
+        tracks = bus_route.bus_route_tracks.to_a
+        # selector の駅 hint や line_name hint で起点候補 A を決める。
+        # multi_try_min_bridge にハマったときも内部で stitch を使うので、その分も map に乗せる。
+        brbs = bus_route.bus_route_bus_stops.reorder(:id).includes(:bus_stop).to_a
+        start_a = StartTerminalSelector.call(
+          tracks,
+          line_name: bus_route.line_name,
+          bus_route_bus_stops: brbs,
+          stitch_fn: ->(t, s) {
+            key = [ bus_route.id, StitchStore.encode_start(s) ]
+            map[key] ||= StitchStore.entry_from_result(stitch_one(t, s))
+            StitchStore.result_from_entry(map[key])
+          }
+        )
+
+        # 候補 B = westmost fallback (start: nil)。常に持っておく。
+        b_key = [ bus_route.id, StitchStore.encode_start(nil) ]
+        map[b_key] ||= StitchStore.entry_from_result(stitch_one(tracks, nil))
+
+        if start_a
+          a_key = [ bus_route.id, StitchStore.encode_start(start_a) ]
+          map[a_key] ||= StitchStore.entry_from_result(stitch_one(tracks, start_a))
+          selector_used += 1
+        else
+          fallback_only += 1
+        end
+      end
+    end
+
+    puts "  selector picked start_a: #{selector_used}, fallback only: #{fallback_only}, multi_try fires: #{multi_try}"
+    map
+  end
+
+  # stitcher 1 回呼び出しの薄いラッパ。プロファイル時にここを起点に時間を測る用。
+  def self.stitch_one(tracks, start)
+    TrackStitcher.call_with_diagnostics(tracks, start: start)
+  end
+
+  desc "Stitch all routes' bus_route_tracks into db/data/stitches.csv.gz (does not touch DB)"
+  task generate: :environment do
+    $stdout.sync = true
+    map = compute_stitches
+    path = StitchStore.write(map)
+    puts "Wrote #{path} (#{map.size} entries)"
+  end
+
+  desc "Profile stitch:generate via stackprof (writes tmp/stitch_generate.stackprof)"
+  task profile: :environment do
+    require "stackprof"
+
+    $stdout.sync = true
+    out = "tmp/stitch_generate.stackprof"
+    StackProf.run(mode: :wall, out: out, interval: 1000) do
+      compute_stitches
+    end
+    puts ""
+    puts "Profile saved to #{out}"
+    puts "View top by self time:   bundle exec stackprof #{out} --text --limit 30"
+    puts "View top by total time:  bundle exec stackprof #{out} --text --total --limit 30"
+  end
+end

--- a/lib/tasks/stitch.rake
+++ b/lib/tasks/stitch.rake
@@ -20,8 +20,10 @@ namespace :stitch do
       stitch_one(tracks, start)
     }
 
+    scope = PrefectureFilter.apply(BusRoute.with_fragmented)
+
     ActiveRecord::Base.logger.silence(Logger::WARN) do
-      BusRoute.with_fragmented.find_each do |bus_route|
+      scope.find_each do |bus_route|
         tracks = bus_route.bus_route_tracks.to_a
         # selector の駅 hint や line_name hint で起点候補 A を決める。
         # multi_try_min_bridge にハマったときも内部で stitch を使うので、その分も map に乗せる。
@@ -60,12 +62,17 @@ namespace :stitch do
     TrackStitcher.call_with_diagnostics(tracks, start: start)
   end
 
-  desc "Stitch all routes' bus_route_tracks into db/data/stitches.csv.gz (does not touch DB)"
+  desc "Stitch all routes' bus_route_tracks into db/data/stitches.csv.gz (does not touch DB). Set PREFECTURE=東京都 to filter (skips CSV write)"
   task generate: :environment do
     $stdout.sync = true
     map = compute_stitches
-    path = StitchStore.write(map)
-    puts "Wrote #{path} (#{map.size} entries)"
+    if PrefectureFilter.active?
+      # 部分実行で全体 CSV を上書きすると残り県分の entries が消える。read-only モードで終了。
+      puts "PREFECTURE filter active: skipping CSV write (#{map.size} entries computed in-memory only)"
+    else
+      path = StitchStore.write(map)
+      puts "Wrote #{path} (#{map.size} entries)"
+    end
   end
 
   desc "Profile stitch:generate via stackprof (writes tmp/stitch_generate.stackprof)"


### PR DESCRIPTION
## Summary
パイプラインを単一責任に分割しつつ、`bus_stop_number:generate` / `:diagnose` のホットスポットを潰した。本番への影響は無く (DB スキーマ無変更、`:load` 系も変更なし)、開発者のフィードバックループを短縮するのが目的。

### コミット

1. **Extract stitch into its own rake task** (`7ed5590`): `bus_stop_number:generate` から stitcher を切り出して `stitch:generate` 新設。出力は `db/data/stitches.csv.gz` (21MB)。
2. **Add PREFECTURE filter to stitch / numbering tasks** (`a890182`): `ENV["PREFECTURE"]` で 1 県絞り込み。フィルタ有効時は CSV 上書きを skip して read-only ベンチに専念。
3. **Reuse closest vertex idx from numberer to skip count_inversions projection** (`a4fbb21`): プロファイル top hot spot だった重複 projection (numberer × 2 + count_inversions × 2 + idx_inversions × 1) を、numberer の射影ループに vertex 距離計算を統合して 3 回ぶん削減。
4. **Pluck bus stop coords to skip ActiveRecord overhead in hot loops** (`517cb63`): AR の latitude / longitude へのアクセスが旧プロファイル 21% を占めていたので、`bus_stops` JOIN + pluck で必要 5 列のみ取り Plain Struct にラップ。

### ベンチ (全国 26,715 routes)

| タスク | baseline (v5.4.1) | 本 PR | 削減 |
|---|---|---|---|
| `bus_stop_number:generate` | 186s | 128s | -31% |
| `bus_stop_number:diagnose` | 174s | 110s | -37% |
| `stitch:generate` (新規) | — | 71s | 反復時はスキップ |

### 都道府県絞り込みの効果 (東京都 = 全国の 8.1%, 2,163 routes)

| | 1 反復 | 100 反復 (PDCA) |
|---|---|---|
| baseline (全国 diagnose) | 174s | 17,400s = 4 時間 50 分 |
| 本 PR (`PREFECTURE=東京都` diagnose) | 16s | 71s + 100×16 = 1,671s = 28 分 |

**約 10 倍速、PDCA 100 回で約 4 時間 22 分の節約。**

### 採番結果の同等性

`bus_stop_numbers.csv.gz` の gunzip 後 SHA が develop と完全一致することを各コミット直後に確認済み (アルゴリズム不変、CSV byte-equivalent)。

### 本番への影響

- 新規ファイル `db/data/stitches.csv.gz` (21MB): production にコピーされるが `:load` タスクは無いので DB に投入されない (中間生成物)。
- DB スキーマ変更なし、production の動作は完全に同じ。

## Test plan
- [x] マージ後、ローカルで `bin/rails stitch:generate` → `bin/rails bus_stop_number:generate` が連鎖して動くこと (新パイプライン)
- [x] `PREFECTURE=東京都 bin/rails bus_stop_number:diagnose` が 1 県絞り込みで動くこと (新フィルタ)