### PR TITLE
Use fragmented_only scope to exclude fragmented routes from diagnose

### DIFF
--- a/lib/tasks/bus_stop_number.rake
+++ b/lib/tasks/bus_stop_number.rake
@@ -451,8 +451,9 @@ namespace :bus_stop_number do
       diag_path = "tmp/bus_stop_number_diagnostics.csv"
       diag_rows = result[:diag_rows]
       # compute_assignments は with_fragmented で回す → INCLUDE_FRAGMENTED 未指定なら fragmented 除外。
+      # default_scope { fragmented: false } があるため where(fragmented: true) は 0 件になる。
       unless ENV["INCLUDE_FRAGMENTED"]
-        fragmented_ids = BusRoute.where(fragmented: true).pluck(:id).to_set
+        fragmented_ids = BusRoute.fragmented_only.pluck(:id).to_set
         diag_rows = diag_rows.reject { |row| fragmented_ids.include?(row[0]) }
       end
       write_diagnose_results(diag_rows, diag_path)
@@ -497,7 +498,7 @@ namespace :bus_stop_number do
     rows = result[:diag_rows]
 
     unless ENV["INCLUDE_FRAGMENTED"]
-      fragmented_ids = BusRoute.where(fragmented: true).pluck(:id).to_set
+      fragmented_ids = BusRoute.fragmented_only.pluck(:id).to_set
       rows = rows.reject { |row| fragmented_ids.include?(row[0]) }
     end
 


### PR DESCRIPTION
## Summary
- `bus_stop_number:diagnose` / `bus_stop_number:generate WITH_DIAGNOSTICS=1` の fragmented 路線除外が PR #82 の並列化リファクタ以降に effectively 機能しなくなっていたのを修正。
- `BusRoute.where(fragmented: true).pluck(:id)` は `default_scope { where(fragmented: false) }` と衝突して **常に空配列** を返すため、35 件の fragmented 路線 (例: 富士急シティバス_01_on / ID 12192) が diagnostics CSV に漏れ、`idx_inversions` / `anomaly_jumps` 等の集計値が悪化方向にズレていた。
- `BusRoute.fragmented_only` (= `unscope(where: :fragmented).where(fragmented: true)`) に切り替え。

## 検証
- 修正後の `bus_stop_number:diagnose` 出力 (26680 rows) が `tmp/chi-bus-baseline/v5.5_diagnostics.csv` (= 並列化前 baseline) と **idx_inversions / anomaly_jumps 全列 byte 一致** することを確認。並列化自体は算法出力を変えていないことも同時に裏付け。
- 修正前: 26715 rows (fragmented 35 件混入、`idx_inversions` 合計 8708 / `anomaly_jumps` 合計 29231)
- 修正後: 26680 rows (`idx_inversions` 合計 8583 / `anomaly_jumps` 合計 28945)

## Test plan
- [ ] `bin/rails bus_stop_number:diagnose` の標準出力に "Diagnose target: 26680 routes (EXCLUDING fragmented)" が表示される
- [ ] `tmp/bus_stop_number_diagnostics.csv` の行数が 26681 (header 含む) であること