### PR TITLE
Switch map to cooperative gesture handling

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -20,7 +20,7 @@
 function drawMap(markersJson, polylinesJson, busStopsCount, centerMakerImagePath) {
   if (!document.body.meta) { document.body.meta = new Object(); }
   handler = Gmaps.build('Google');
-  handler.buildMap({ provider: { scrollwheel: false, MinZoom:15 }, internal: {id: 'map'}}, function(){
+  handler.buildMap({ provider: { gestureHandling: 'cooperative' }, internal: {id: 'map'}}, function(){
     var markers = $.map(markersJson, function(busStop){
       var marker = handler.addMarker(busStop, { visible: false });
       marker.id = busStop.id;


### PR DESCRIPTION
## Summary
`drawMap` の Google Maps プロバイダーオプションを `{ scrollwheel: false, MinZoom: 15 }` から `{ gestureHandling: 'cooperative' }` に置き換え。

### 動作変更
| | 旧 (`scrollwheel: false`) | 新 (`gestureHandling: 'cooperative'`) |
|---|---|---|
| デスクトップ | スクロールで地図ズーム不可 / **ドラッグでパン可** | Ctrl/⌘ + スクロールでズーム / **ドラッグでパン可** |
| モバイル | ピンチズームが実用上効きにくい (旧 API 仕様の副作用) | **2 本指パン + ピンチズーム** が明示的に有効 |

10 年前にかけた「PC でページをスクロールしている時に地図に当たってズームしてしまう事故」を防ぐ意図はそのままに、モバイルでピンチが効くようにする変更。

### `MinZoom: 15` の削除
合わせて `MinZoom: 15` を削除。Google Maps の正式オプションは小文字 `minZoom` なので 10 年間タイポで実は機能していなかった。タイポ修正で有効化する案もあったが:
- `fitMapToBounds` が広域路線 (例: 高速バス `bus_routes/4849` 金沢⇔東京) で zoom 12 程度を要求 → `minZoom: 15` で強制クランプすると全体表示が壊れる
- 10 年間誰も気づいていなかった = 実害なし → 不要なコード

…ということで削除する。

## Test plan
- [ ] PC ブラウザで地図上をスクロール → ページがスクロールし、地図はズームしない
- [ ] PC ブラウザで Ctrl/⌘ + スクロール → 地図がズームする
- [ ] PC ブラウザで地図をドラッグ → パンする
- [ ] スマホで地図上を 1 本指ドラッグ → ページがスクロールし、地図はパンしない
- [ ] スマホで地図上を 2 本指ドラッグ → 地図がパンする
- [ ] スマホで地図上をピンチイン/アウト → 地図がズームする
- [ ] 高速バス系の広域路線 (例: `/bus_routes/4849`) でも全体表示が崩れていない