### PR TITLE
Enrich map marker and polyline interactions

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -24,6 +24,7 @@ function drawMap(markersJson, polylinesJson, busStopsCount, centerMakerImagePath
     var markers = $.map(markersJson, function(busStop){
       var marker = handler.addMarker(busStop, { visible: false });
       marker.id = busStop.id;
+      marker.path = busStop.path;
       marker.panTo = function() {};
       return marker;
     });
@@ -47,7 +48,8 @@ function drawMap(markersJson, polylinesJson, busStopsCount, centerMakerImagePath
     handler.fitMapToBounds();
     // markers / polylines が揃ったタイミングで common.js 側に通知し、Google Maps の
     // mouseover / mouseout / click listener をまとめて attach させる。polyline 無しの
-    // ページでも将来マーカー側 hook を足したいので if (polylinesJson) の外で trigger する。
+    // ページ (バス停詳細など) でもマーカー側 hook を効かせたいので
+    // if (polylinesJson) の外で trigger する。
     $(document).trigger("chi-bus:map-ready");
     var centerMarker = handler.addMarker({
       "lat": handler.getMap().getCenter().lat(),

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -45,6 +45,10 @@ function drawMap(markersJson, polylinesJson, busStopsCount, centerMakerImagePath
     }
     handler.bounds.extendWith(markers);
     handler.fitMapToBounds();
+    // markers / polylines が揃ったタイミングで common.js 側に通知し、Google Maps の
+    // mouseover / mouseout / click listener をまとめて attach させる。polyline 無しの
+    // ページでも将来マーカー側 hook を足したいので if (polylinesJson) の外で trigger する。
+    $(document).trigger("chi-bus:map-ready");
     var centerMarker = handler.addMarker({
       "lat": handler.getMap().getCenter().lat(),
       "lng": handler.getMap().getCenter().lng(),

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -28,6 +28,19 @@ function drawMap(markersJson, polylinesJson, busStopsCount, centerMakerImagePath
       marker.panTo = function() {};
       return marker;
     });
+    // 単独路線の水色マーカーは HDPI 画像 (52x74) を default と同じ 26x37 で描かせる。
+    // gmaps4rails の marker.picture API は scaledSize を露出していないので、生成後に
+    // setIcon で scaledSize を後がけする。HDPI 画面でも default と同じ解像度を保つ。
+    $.each(markers, function(){
+      var serviceObject = this.getServiceObject();
+      var icon = serviceObject.getIcon();
+      if (icon && typeof icon === 'object' && icon.url && icon.url.indexOf('?style=single') !== -1) {
+        serviceObject.setIcon({
+          url: icon.url,
+          scaledSize: new google.maps.Size(26, 37)
+        });
+      }
+    });
     $.each(markers, function(index){
       var marker = this.getServiceObject();
       window.setTimeout(function(){

--- a/app/assets/javascripts/common.js
+++ b/app/assets/javascripts/common.js
@@ -73,9 +73,10 @@
   // application.js は 1 つの bus_route に対して複数の polyline（tracks の数だけ）を作ることがあり、
   // 同じ id を共有している。ホバー時はそれら全部を一括で強調表示したいので、find（最初の 1 件）ではなく filter を使う。
   // marker は 1 つの bus_stop につき 1 つだけだが、コードを揃えるため同じ関数で扱う。
-  // data 属性は文字列で取り出されるので "+ ''" で文字列化して比較している。
+  // data 属性側は文字列、polyline.id 側は number で来るので両側を "" 付与で文字列化して比較する。
   function findMapObjectsById(collection, id) {
-    return (collection || []).filter(function(obj) { return obj.id + "" === id; });
+    const target = id + "";
+    return (collection || []).filter(function(obj) { return obj.id + "" === target; });
   }
 
   // document.body.meta は drawMap() が呼ばれて初めて設定される。
@@ -84,14 +85,19 @@
     return document.body.meta || {};
   }
 
-  // 路線リンクのホバー: 対応する polyline 群を強調表示／元に戻す
-  function setBusRouteHighlight($link, highlighted) {
-    const id = $link.attr("data-bus-route-link");
+  // 指定 id を持つ polyline 群を強調表示／元に戻す。
+  // リスト側 hover とマップ側 hover の両方から呼ぶので $link ではなく id で受ける。
+  function setBusRouteHighlightById(id, highlighted) {
     const polylines = findMapObjectsById(getMapMeta().polylines, id);
     const style = highlighted ? POLYLINE_STYLE_HIGHLIGHTED : POLYLINE_STYLE_NORMAL;
     polylines.forEach(function(polyline) {
       polyline.getServiceObject().setOptions(style);
     });
+  }
+
+  // 路線リンクのホバー: data 属性から id を取り出して setBusRouteHighlightById に委譲
+  function setBusRouteHighlight($link, highlighted) {
+    setBusRouteHighlightById($link.attr("data-bus-route-link"), highlighted);
   }
 
   // 停留所リンクのホバー: 対応する marker をバウンスさせる／止める
@@ -131,6 +137,26 @@
     });
     $(document).on("mouseleave click", SELECTOR_BUS_STOP_LINK, function() {
       setBusStopAnimation($(this), null);
+    });
+
+    // マップ上の polyline 自身に hover した時のハイライト。
+    // polyline は drawMap の async コールバック内で初めて生成されるため、
+    // application.js がそこで chi-bus:map-ready を trigger する。受け取った時点で
+    // Google Maps の mouseover/mouseout listener を attach する。
+    $(document).on("chi-bus:map-ready", function() {
+      (getMapMeta().polylines || []).forEach(function(polyline) {
+        const serviceObject = polyline.getServiceObject();
+        google.maps.event.addListener(serviceObject, "mouseover", function() {
+          setBusRouteHighlightById(polyline.id, true);
+        });
+        google.maps.event.addListener(serviceObject, "mouseout", function() {
+          setBusRouteHighlightById(polyline.id, false);
+        });
+        // polyline 自身をクリックしたら対応する bus_route 詳細ページへ遷移
+        google.maps.event.addListener(serviceObject, "click", function() {
+          window.location.href = "/bus_routes/" + polyline.id;
+        });
+      });
     });
   });
 })();

--- a/app/assets/javascripts/common.js
+++ b/app/assets/javascripts/common.js
@@ -157,6 +157,39 @@
           window.location.href = "/bus_routes/" + polyline.id;
         });
       });
+
+      // マーカー hover 用の即時 tooltip。Google Maps の Marker は `title` 属性を経由した
+      // ネイティブブラウザ tooltip を出すが、500ms 級の遅延があって体感が遅い。
+      // 共有 InfoWindow に title 文字列だけ流し込んで mouseover で即開く。
+      // ネイティブ tooltip は二重表示防止のために setTitle("") で外す。
+      const hoverInfoWindow = new google.maps.InfoWindow({
+        disableAutoPan: true,
+        headerDisabled: true
+      });
+      (getMapMeta().markers || []).forEach(function(marker) {
+        const serviceObject = marker.getServiceObject();
+        const title = serviceObject.getTitle();
+        if (!title) return;
+        serviceObject.setTitle("");
+        // gmaps4rails が marker 生成時に登録した click→InfoWindow ハンドラを外す。
+        // クリック時は吹き出しを出さず、直接 marker.path へ遷移させたいため。
+        google.maps.event.clearListeners(serviceObject, "click");
+        google.maps.event.addListener(serviceObject, "mouseover", function() {
+          hoverInfoWindow.setContent(title);
+          hoverInfoWindow.open({ map: serviceObject.getMap(), anchor: serviceObject });
+        });
+        google.maps.event.addListener(serviceObject, "mouseout", function() {
+          hoverInfoWindow.close();
+        });
+        // 通常のバス停 → /bus_stops/:id、Google Places の Place →
+        // /bus_stops?position=lat,lng (周辺検索) に飛ぶ。
+        // path は build_markers が bus_stop_or_place_path で生成して json に含めている。
+        google.maps.event.addListener(serviceObject, "click", function() {
+          if (!marker.path) return;
+          hoverInfoWindow.close();
+          window.location.href = marker.path;
+        });
+      });
     });
   });
 })();

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -92,6 +92,13 @@ h1, .h1, h2, .h2, h3, .h3 {
   // dvh はモバイル Safari のアドレスバー表示状態に追従するため、100vh で起きていた「実画面より大きくなる」問題が出ない。
   height: calc(100dvh - 120px);
   margin-bottom: 10px;
+
+  // 通過路線が 1 本だけの bus_stop マーカー。helper で marker.picture に
+  // `?style=single` クエリ付きの URL を渡し、ここで hue-rotate して水色化する。
+  // 画像実体は Google Maps の default 赤マーカー (spotlight-poi3) と同一形状なので、色だけ変わる。
+  img[src*="?style=single"] {
+    filter: hue-rotate(180deg);
+  }
 }
 
 /*

--- a/app/controllers/bus_routes_controller.rb
+++ b/app/controllers/bus_routes_controller.rb
@@ -2,7 +2,10 @@ class BusRoutesController < ApplicationController
   def show
     # fragmented route も直接 URL からは表示する (default_scope を解除)。
     # 一覧/検索からは default_scope で自然と除外される。
-    @bus_route = BusRoute.with_fragmented.includes(bus_stops: [ :bus_route_bus_stops ])
+    # bus_stops の bus_routes も preload しておく。マーカー title (「○○駅（10）」のような
+    # 通過路線数) を build_markers が bus_stop_badge 経由で計算するため、ここで loaded で
+    # ないと per-marker で N+1 になる。
+    @bus_route = BusRoute.with_fragmented.includes(bus_stops: [ :bus_routes, :bus_route_bus_stops ])
                           .order("bus_route_bus_stops.bus_stop_number").find(params[:id])
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -11,8 +11,24 @@ module ApplicationHelper
     markers += Gmaps4rails.build_markers(bus_stops) do |bus_stop, marker|
       marker.lat bus_stop.latitude
       marker.lng bus_stop.longitude
+      badge = bus_stop_badge(bus_stop)
       # title はホバー時の即時 tooltip 文言。「渋谷駅（10）」のように停留所名 + 通過路線数 (Place は「周辺」)。
-      marker.title "#{bus_stop.name}（#{bus_stop_badge(bus_stop)}）"
+      marker.title "#{bus_stop.name}（#{badge}）"
+      # 通過路線が 1 本だけの bus_stop は default の赤マーカーと同じ Google CDN 画像を
+      # 指すが、`?style=single` query で <img src> を distinct 化し、CSS 側で
+      # `img[src*="?style=single"]` を hue-rotate して水色化する。形状は default と
+      # 完全一致するので「色だけ違う」UX を実現できる。Place や 2 路線以上の bus_stop は
+      # marker.picture を設定しないため Google Maps の default 赤マーカーが使われる。
+      if badge == 1
+        # HDPI 版 (52x74) を渡し、display は default と同じ 26x37 にするため
+        # application.js 側で setIcon({scaledSize: 26x37}) を後がけする。
+        # gmaps4rails の marker.picture API は scaledSize を露出していないため。
+        marker.picture({
+          url: "https://maps.gstatic.com/mapfiles/api-3/images/spotlight-poi3_hdpi.png?style=single",
+          width: "26",
+          height: "37"
+        })
+      end
       # path はマーカークリック時のジャンプ先。BusStop なら詳細ページ、Google Places の
       # Place なら同座標の周辺検索 (= /bus_stops?position=lat,lng) になる。
       marker.json({ id: bus_stop.id, path: bus_stop_or_place_path(bus_stop) })

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -11,9 +11,11 @@ module ApplicationHelper
     markers += Gmaps4rails.build_markers(bus_stops) do |bus_stop, marker|
       marker.lat bus_stop.latitude
       marker.lng bus_stop.longitude
-      marker.title bus_stop.name
-      marker.infowindow render partial: "application/infowindow", locals: { bus_stop: bus_stop }
-      marker.json({ id: bus_stop.id })
+      # title はホバー時の即時 tooltip 文言。「渋谷駅（10）」のように停留所名 + 通過路線数 (Place は「周辺」)。
+      marker.title "#{bus_stop.name}（#{bus_stop_badge(bus_stop)}）"
+      # path はマーカークリック時のジャンプ先。BusStop なら詳細ページ、Google Places の
+      # Place なら同座標の周辺検索 (= /bus_stops?position=lat,lng) になる。
+      marker.json({ id: bus_stop.id, path: bus_stop_or_place_path(bus_stop) })
     end
     markers
   end

--- a/app/views/application/_infowindow.html.erb
+++ b/app/views/application/_infowindow.html.erb
@@ -1,7 +1,0 @@
-<div>
-  <%= link_to bus_stop.name, bus_stop_or_place_path(bus_stop) %>
-</div>
-<div>
-  <%= bus_stop.formatted_address %>
-</div>
-

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -2,6 +2,10 @@ require "test_helper"
 
 class ApplicationHelperTest < ActionView::TestCase
   include ApplicationHelper
+  # build_markers から呼ばれる bus_stop_or_place_path は BusStopsHelper にあるので
+  # テスト側でも明示的に include する。本番の view 側は helper :all で全 helper が
+  # 自動で揃うため必要ない。
+  include BusStopsHelper
 
   test "should build_markers return empty" do
     results = build_markers([])
@@ -13,22 +17,21 @@ class ApplicationHelperTest < ActionView::TestCase
       BusStop.new(id: 1, latitude: 3.5, longitude: 4.5, name: "name_1"),
       BusStop.new(id: 2, latitude: 5.5, longitude: 6.5, name: "name_2")
     ]
-    stub(:render, true) do
-      results = build_markers(bus_stops)
-      assert_equal 2, results.length
+    results = build_markers(bus_stops)
+    assert_equal 2, results.length
 
-      assert_equal 1, results[0][:id]
-      assert_equal 3.5, results[0][:lat]
-      assert_equal 4.5, results[0][:lng]
-      assert_equal "name_1", results[0][:marker_title]
-      assert results[0][:infowindow]
+    assert_equal 1, results[0][:id]
+    assert_equal "/bus_stops/1", results[0][:path]
+    assert_equal 3.5, results[0][:lat]
+    assert_equal 4.5, results[0][:lng]
+    # 路線が紐付いていない BusStop なので路線数 0、title は「name（0）」になる。
+    assert_equal "name_1（0）", results[0][:marker_title]
 
-      assert_equal 2, results[1][:id]
-      assert_equal 5.5, results[1][:lat]
-      assert_equal 6.5, results[1][:lng]
-      assert_equal "name_2", results[1][:marker_title]
-      assert results[1][:infowindow]
-    end
+    assert_equal 2, results[1][:id]
+    assert_equal "/bus_stops/2", results[1][:path]
+    assert_equal 5.5, results[1][:lat]
+    assert_equal 6.5, results[1][:lng]
+    assert_equal "name_2（0）", results[1][:marker_title]
   end
 
   test "should build_markers return position markers" do
@@ -43,10 +46,8 @@ class ApplicationHelperTest < ActionView::TestCase
   end
 
   test "should build_markers return bus stops and position markers" do
-    stub(:render, true) do
-      results = build_markers([ BusStop.new(id: 1) ], "1.5,2.5")
-      assert_equal 2, results.length
-    end
+    results = build_markers([ BusStop.new(id: 1) ], "1.5,2.5")
+    assert_equal 2, results.length
   end
 
   test "shuld build_routes return empty" do


### PR DESCRIPTION
## Summary
地図上のマーカー / ポリラインに対するインタラクションを 3 段階で増強する。3 commit 構成。

### 1. ポリライン hover/click
- polyline 自身に hover → 同じ `bus_route_id` の polyline 群が赤くハイライト
- polyline をクリック → `/bus_routes/:id` へ遷移
- マーカー/ポリラインが揃ったタイミングで `chi-bus:map-ready` カスタムイベントを発火し、`common.js` がそれを受けて Google Maps の event listener を attach する基盤も導入

### 2. マーカー hover tooltip + click 直接遷移
- ホバー: ネイティブ tooltip (`title` 属性) の 500ms 級の遅延をやめ、共有 InfoWindow で「渋谷駅（10）」のように `名前 + 通過路線数` を即時表示 (Place は「周辺」)
- クリック: 旧来の「吹き出し → リンククリック」の 2 段階をやめ、`marker.path` に乗せておいた URL へ直接遷移する。通常 BusStop は `/bus_stops/:id`、Google Places の Place は `/bus_stops?position=lat,lng` (周辺検索)
- `app/views/application/_infowindow.html.erb` partial と `marker.infowindow render` 呼び出しを削除し、サーバサイド render と JSON サイズを軽くする
- `bus_routes#show` の preload に `bus_stops: :bus_routes` を追加 (`bus_stop_badge` の N+1 回避)

### 3. 単独路線マーカーの水色化
- 通過路線が 1 本だけのバス停を視覚的に区別する。乗り換え不可な末端と、ハブ的に複数路線が通る停留所を一目で見分けたい
- 実装は CSS filter で済ませる。`marker.picture` に `spotlight-poi3_hdpi.png?style=single` を渡す (画像は default 赤マーカーと完全同一、クエリ文字列だけで `<img src>` を distinct 化)。CSS 側で `img[src*="?style=single"]` を `filter: hue-rotate(180deg)` して水色化
- HDPI 対応: gmaps4rails が `scaledSize` を露出していないので、`application.js` の marker 生成直後に `setIcon({ scaledSize: 26x37 })` を後がけ

## Test plan
- [ ] `/bus_routes/8588` で polyline 上に mouseover → 全 polyline が赤くなる、mouseout で青に戻る
- [ ] `/bus_stops/:id` (複数 polyline 表示) で 1 つの polyline に mouseover → 同じルートの polyline だけ赤くなる
- [ ] polyline をクリック → 対応する `/bus_routes/:id` に遷移
- [ ] マーカーに mouseover → 即座に「○○駅（n）」が表示される (ネイティブ tooltip の遅延がない)
- [ ] 通常マーカーをクリック → `/bus_stops/:id` に遷移 (吹き出しは出ない)
- [ ] Place マーカー (`/bus_stops?q=東京スカイツリー駅前展望デッキ` 等) のクリック → `/bus_stops?position=lat,lng` に遷移
- [ ] 通過路線 1 本の bus_stop は水色マーカー、2 本以上は赤マーカーになっている
- [ ] HDPI/Retina 画面で水色マーカーが crisp に描画される (display 26x37、`spotlight-poi3_hdpi.png` の 52x74 を scaledSize で 50% scale)
- [ ] リスト側 bus_route リンクへの hover / click による既存ハイライト挙動が回帰していない