### PR TITLE
Fix scan_ruby CI: bump brakeman / net-imap / puma

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -253,7 +253,7 @@ GEM
       date
       stringio
     public_suffix (7.0.5)
-    puma (8.0.1)
+    puma (8.0.2)
       nio4r (~> 2.0)
     raabro (1.4.0)
     racc (1.8.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -210,7 +210,7 @@ GEM
     msgpack (1.8.0)
     multi_xml (0.9.0)
       bigdecimal (>= 3.1, < 5)
-    net-imap (0.6.4)
+    net-imap (0.6.4.1)
       date
       net-protocol
     net-pop (0.1.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -89,7 +89,7 @@ GEM
     bootstrap-sass (3.4.1)
       autoprefixer-rails (>= 5.2.1)
       sassc (>= 2.0.0)
-    brakeman (8.0.4)
+    brakeman (8.0.5)
       racc
     builder (3.3.0)
     bundler-audit (0.9.3)


### PR DESCRIPTION
## Summary
`scan_ruby` ジョブが連続失敗していたため、原因の 3 件の bump を 1 PR にまとめて修復する:

- brakeman 8.0.4 → 8.0.5: `bin/brakeman` が新バージョン未取得時に exit 5 で落ちる挙動になっていた
- net-imap 0.6.4 → 0.6.4.1: command injection / DoS の CVE 3 件 (CVE-2026-47240 / 47241 / 47242)
- puma 8.0.1 → 8.0.2: PROXY Protocol v1 関連の High CVE 2 件 (CVE-2026-47736 / 47737)

puma 部分は Dependabot PR #87 と重複するので、こちらをマージ後 #87 は close する想定。

ローカルで `bin/brakeman --no-pager` / `bin/bundler-audit` がどちらも clean になることを確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)