### PR TITLE
Untrack stitches.csv.gz from git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@
 /coverage
 /.claude/
 /.playwright-mcp/
+
+# bus_stop_number:generate のキャッシュ。production には載らず、ローカルでオンデマンド再生成。
+/db/data/stitches.csv.gz

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,7 +116,7 @@ XML + JSON のソースから `db/data/*.csv.gz` を生成し、gzip 圧縮し�
 生成タスク (CSV はそれぞれ git に commit、最新ソースやロジック変更時だけ再生成):
 
 - `data:generate` — N07 / P11 XML をパースし、`db/data/bus_stops.csv.gz` / `bus_routes.csv.gz` / `bus_route_tracks.csv.gz` / `bus_route_bus_stops.csv.gz` を出力。
-- `stitch:generate` — DB の `bus_route_tracks` を TrackStitcher で連結し、A/B 起点候補 (StartTerminalSelector による hint と最西端 fallback) の flat_coords を per-route で `db/data/stitches.csv.gz` に出力。`bus_stop_number:generate` の前提となる中間生成物 (これが無いと raise する)。`:load` タスクは無く、production の DB スキーマには反映されない (Heroku の db:seed でもスキップされる)。
+- `stitch:generate` — DB の `bus_route_tracks` を TrackStitcher で連結し、A/B 起点候補 (StartTerminalSelector による hint と最西端 fallback) の flat_coords を per-route で `db/data/stitches.csv.gz` に出力。`bus_stop_number:generate` の前提となるローカルキャッシュ (これが無いと raise する) で、`.gitignore` 対象。production には載らず、Heroku の db:seed でもスキップされる。ローカルで採番反復を始める前に 1 度だけ走らせれば、以後は TrackStitcher を invalidate するロジック変更時のみ再走すれば良い。
 - `bus_stop_number:generate` — `stitches.csv.gz` を読み込んで numberer + orienter で `db/data/bus_stop_numbers.csv.gz` を生成。
 - `geocode:generate` — `db/isj/` の ISJ CSV を読み、各 bus_stop の最近接 entry から `db/data/geocoding.csv.gz` (city, formatted_address) を生成。ISJ raw データ (`db/isj/`) はダウンロード必要、生成 CSV だけ commit する。
 - `keyword:generate` — kakasi で `db/data/keywords.csv.gz` を生成 (`libkakasi.so.2` 要、Dockerfile.dev の kakasi パッケージに同梱)。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,7 +113,7 @@ XML + JSON のソースから `db/data/*.csv.gz` を生成し、gzip 圧縮し�
 
 タスク：
 
-生成タスク (CSV はそれぞれ git に commit、最新ソースやロジック変更時だけ再生成):
+生成タスク (CSV はそれぞれ git に commit、最新ソースやロジック変更時だけ再生成。`stitches.csv.gz` のみ例外で `.gitignore` 対象):
 
 - `data:generate` — N07 / P11 XML をパースし、`db/data/bus_stops.csv.gz` / `bus_routes.csv.gz` / `bus_route_tracks.csv.gz` / `bus_route_bus_stops.csv.gz` を出力。
 - `stitch:generate` — DB の `bus_route_tracks` を TrackStitcher で連結し、A/B 起点候補 (StartTerminalSelector による hint と最西端 fallback) の flat_coords を per-route で `db/data/stitches.csv.gz` に出力。`bus_stop_number:generate` の前提となるローカルキャッシュ (これが無いと raise する) で、`.gitignore` 対象。production には載らず、Heroku の db:seed でもスキップされる。ローカルで採番反復を始める前に 1 度だけ走らせれば、以後は TrackStitcher を invalidate するロジック変更時のみ再走すれば良い。


### PR DESCRIPTION
## Summary
`db/data/stitches.csv.gz` (31 MB) は TrackStitcher の per-route 計算結果を起点候補 A/B でキャッシュする中間生成物。production には載らず (`:load` タスクなし、Heroku の `db:seed` でもスキップ)、ローカルで `bus_stop_number:generate` が stitcher を毎回呼ばないようにするための高速化キャッシュとしてのみ機能している。

31 MB のファイルが git 追跡されていたため、TrackStitcher / StartTerminalSelector のロジック変更時に丸ごと diff として記録される。production 不要な中間生成物を git に置く価値が薄いので untrack する。

- `.gitignore` に `/db/data/stitches.csv.gz` を追加
- 既存のファイルを `git rm --cached` で追跡解除 (ローカルファイルは保持)
- `CLAUDE.md` の該当節を「ローカルキャッシュ、`.gitignore` 対象」と書き換え、前置きにも例外として追記

新規開発者は採番反復の前に 1 度 `stitch:generate` を走らせる必要がある (~70s)。ローカルでの自動再生成は今後の検討事項。

🤖 Generated with [Claude Code](https://claude.com/claude-code)